### PR TITLE
Updated IntoValue lookup table and selected EUTT names 

### DIFF
--- a/prep/eutt-sponsors-of-interest.csv
+++ b/prep/eutt-sponsors-of-interest.csv
@@ -10,33 +10,25 @@ University Erlangen-Nuremberg,Erlangen
 Goethe University,Frankfurt
 University of Freiburg,Freiburg
 University of Giessen,Giessen
-University Hospital Giessen and Marburg,Giessen
 University of Göttingen,Göttingen
 Medical University Greifswald,Greifswald
 Martin Luther University Halle-Wittenberg,Halle-Wittenberg
 University of Hamburg,Hamburg
 Hannover Medical School,Hannover
-Heidelberg University,Heidelberg
 Heidelberg University Hospital,Heidelberg
 Saarland University,Homburg
 Friedrich Schiller University Jena,Jena
-University of Kiel,Kiel
-Schleswig-Holstein University Hospital,Kiel
 University of Cologne,Köln
 Leipzig University,Leipzig
-Schleswig-Holstein University Hospital,Lübeck
 University of Munich (Ludwig-Maximilians),LMU München
 Otto von Guericke University Magdeburg,Magdeburg
 Johannes Gutenberg University of Mainz,Mainz
-Heidelberg University,Mannheim
-Heidelberg University Hospital,Mannheim
 Philipps-University Marburg,Marburg
-University Hospital Giessen and Marburg,Marburg
 University of Münster,Münster
 University of Regensburg,Regensburg
 Universität Rostock,Rostock
+Schleswig-Holstein University Hospital,Schleswig-Holstein
 Technical University of Munich,TU München
-Eberhard Karls University Tübingen,Tübingen
 University Hospital Tübingen,Tübingen
 University of Ulm,Ulm
 University of Witten/Herdecke,Witten/Herdecke

--- a/prep/intovalue-city-transforms.csv
+++ b/prep/intovalue-city-transforms.csv
@@ -18,10 +18,8 @@ Hannover,Hannover
 Heidelberg,Heidelberg
 Homburg,Homburg
 Jena,Jena
-Schleswig-Holstein,Kiel
 Köln,Köln
 Leipzig,Leipzig
-Schleswig-Holstein,Lübeck
 LMU_München,LMU München
 Magdeburg,Magdeburg
 Mainz,Mainz
@@ -30,6 +28,7 @@ Marburg,Marburg
 Münster,Münster
 Regensburg,Regensburg
 Rostock,Rostock
+Schleswig-Holstein,Schleswig-Holstein
 TU_München,TU München
 Tübingen,Tübingen
 Ulm,Ulm


### PR DESCRIPTION
- Updated the IntoValue lookup table to be consistent with original IntoValue dataset (keep Schleswig-Holstein instead of separating out Kiel and Lübeck)
- Updated selected EUTT names as follows:
  - Removed name for Mannheim as no EUTT name available for Mannheim
    - TBD: could consider using Heidelberg EUTT name, since the Mannheim UMC is located in Heidelberg university
  - Extracted EUTT name for "Schleswig-Holstein" instead of separate names for Kiel and Lübeck (as above)
  - For UMCs with multiple names in EUTT: we only selected the name with the most trials in EUCTR. This applies to Giessen, Marburg, Heidelberg, and Tübingen.
    - TODO: check if trials are double counted if all available names are selected for a given institution. If not, could consider adding all available names for all institutions.