### PR TITLE
Updates to methods/tool tips and edits to work with updated IV dataset

### DIFF
--- a/all_umc_plots.R
+++ b/all_umc_plots.R
@@ -79,14 +79,14 @@ plot_allumc_clinicaltrials_trn <- function (dataset, color_palette) {
 
         umc_numer_ft <- dataset %>%
             filter(city == umc) %>%
-            select(has_iv_trn_ft_pdf) %>%
-            filter(has_iv_trn_ft_pdf == TRUE) %>%
+            select(has_iv_trn_ft) %>%
+            filter(has_iv_trn_ft == TRUE) %>%
             nrow()
 
         umc_numer_either <- dataset %>%
             filter(
                 city == umc,
-                has_iv_trn_abstract == TRUE | has_iv_trn_ft_pdf == TRUE
+                has_iv_trn_abstract == TRUE | has_iv_trn_ft == TRUE
             ) %>%
             nrow()
 
@@ -95,8 +95,8 @@ plot_allumc_clinicaltrials_trn <- function (dataset, color_palette) {
             filter(
                 has_publication == TRUE,
                 publication_type == "journal publication",
-                has_ft_pdf,
-                ! is.na(has_iv_trn_ft_pdf)
+                has_ft,
+                ! is.na(has_iv_trn_ft)
             ) %>%
             nrow()
         

--- a/all_umcs_page.R
+++ b/all_umcs_page.R
@@ -1,37 +1,39 @@
-allumc_openaccess_tooltip <- strwrap("The Open Access (OA) metric shows the percentage of
-                              research publications that are OA. This analysis was
-                              limited to trials with a
-                              journal publication for which a DOI has been assigned.
-                              We only considered the following categories as OA
-                              in this dashboard: Gold OA, Green OA, and Hybrid OA.
-                              Gold OA denotes publication
-                              in a pure OA journal. Green OA denotes a freely
-                              available repository version. Hybrid OA denotes an
-                              OA publication in a journal which offers both a
-                              subscription based model as well as an OA option.
-                              The number of publications and their OA
-                              status can be visualised by clicking on the toggle
-                              next to the plot. Here, further categories are
-                              included: Bronze denotes a publication which is
-                              freely available on the journal page, but without a
-                              clear open license; Closed publications are not freely
-                              available; \"No data\" refers to publications which
-                              could not be resolvd in Unpaywall. As one publication
-                              can have several OA versions, we define a hierarchy
-                              and for each publication only assign the OA category
-                              with the highest priority. Here, we
-                              used a hierarchy of gold - hybrid - green. More
-                              information can be found in the Methods page.")
+allumc_openaccess_tooltip <- strwrap("This metric shows the percentage of
+                              publications that are Open Access (OA). This analysis was
+                              limited to trials with a journal publication and a DOI.
+                              Publications can have different OA statuses which are color-coded.
+                              Gold OA denotes a publication in an OA journal. Green
+                              OA denotes a freely available repository version.
+                              Hybrid OA denotes an OA publication in a journal
+                              which offers both a subscription based model as well
+                              as an OA option. As publications can have several
+                              OA versions, we defined a hierarchy for categories
+                              and for each publication only assigned the category 
+                              with the highest priority. Here, we used a hierarchy
+                              of gold - hybrid - green. The absolute number of
+                              publications and their OA status can be visualised
+                              by clicking on the toggle next to the plot. Here,
+                              further categories not considered as Open Access
+                              in this dashboard are also included. More information
+                              can be found in the Methods page.")
+
+lim_allumc_openaccess_tooltip <- strwrap("Unpaywall only stores information for publications
+                                  which have a DOI assigned by Crossref. Publications
+                                  without a Crossref DOI had to be excluded from
+                                  the OA analysis. The OA percentage is not a fixed
+                                  number, but changes over time as some publications
+                                  become accessible with a delay. The current data
+                                  was retrieved on: 15/07/2021.")
 
 allumc_greenoa_tooltip <- strwrap("This metric measures how many paywalled publications
                             with the potential for green OA have been made available
                             via this route. This analysis was limited to trials
-                            with a journal publication for which a DOI has been assigned.
+                            with a journal publication and a DOI.
                             In a first step, we identified publications which are
-                             only accessible via Green OA (in a repository). To do
+                             only accessible in a repository (Green OA only). To do
                              so, we queried the Unpaywall API  with the following
                              hierarchy: gold - hybrid - bronze - green - 
-                             closed. We then identified how many paywalled publications
+                             closed. Next, we identified how many paywalled publications
                              could technically be made openly accessible based on
                              self-archiving permissions. We obtained this information
                              by querying the Shareyourpaper.org permissions API (OA.Works).
@@ -40,9 +42,20 @@ allumc_greenoa_tooltip <- strwrap("This metric measures how many paywalled publi
                              archiving the accepted or published version in an
                              institutional repository, and if the embargo had elapsed
                              (if applicable). Click on the toggle on the left to
-                             view the number of paywalled publications and their
+                             view the absolute number of paywalled publications and their
                              potential for self-archiving. More information can be
                              found in the Methods page.")
+
+lim_allumc_greenoa_tooltip <- strwrap("Not all publications queried were resolved
+                                in Unpaywall and ShareYourPaper. We also only extracted
+                                permissions data for publications which have a
+                                \"best permission\" in the Shareyourpaper.org database.
+                                The date at which a publication can be made openly
+                                accessible via self-archiving depends on the publication
+                                date and the length of the embargo (if any). Therefore,
+                                the number of paywalled publications with the potential
+                                for green OA will change over time. The Shareyourpaper
+                                permissions API was queried on 23/07/2021.")
 
 allumc_opendata_tooltip <- strwrap("The Open Data metric measures the percentage of publications in English and for
                             which the full text could be screened that mention sharing of data.
@@ -50,54 +63,141 @@ allumc_opendata_tooltip <- strwrap("The Open Data metric measures the percentage
                             reproduced. Additionally, shared datasets can be reused and combined by other
                             scientists to answer new research questions.")
 
+lim_allumc_opendata_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all Open Data publications and finds false positive cases (no manual check of the results). ODDPub also does not verify that the dataset is available and whether it fulfills our definition of Open Data. Finally, Open Data is not relevant for all publications.")
+
 allumc_opencode_tooltip <- strwrap("The Open Code metric measures the percentage of publications in English and for
                             which the full text could be screened that mention sharing of code.
                             Like openly shared data, Open Code makes research more transparent, as research
                             findings can be reproduced.")
 
-allumc_clinicaltrials_trn_tooltip <- strwrap("This metric measures how many publications classified by PubMed as clinical trial
-                        publications report a trial registration number (TRN) in the abstract and in the
-                        secondary identifier metadata of the publication. Reporting of clinical trial registration
-                        numbers in related publications facilitates transparent linkage between registration and
-                        publication. The CONSORT as well as the ICMJE Recommendations for the Conduct, Reporting,
-                        Editing, and Publication of Scholarly Work in Medical Journals call for reporting
-                        <i>&#39trial registration number and name of the trial register&#39</i> in both the
-                       full-text and abstract.")
+lim_allumc_opencode_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all publications with Open Code and finds false positive cases (no manual check of the results). ODDPub also does not verify that the code is available and whether it fulfills our definition of Open Code Finally, Open Code is not relevant for all publications.")
 
-allumc_clinicaltrials_sumres_tooltip <- strwrap("This metric measures how many clinical trials registered in the
-                        EU Clinical Trials Register that are due to report their results have already
-                        done so. A trial is due to report its results 12 month after trial completion.
-                        The data were retrieved from the EU Trials Tracker by the EBM DataLab
-                        (eu.trialstracker.net). Clinical trials are expensive and have often many contributing
-                        patients. A fast dissemination of the trial results is crucial to make the evidence
-                        gained in those trials available. The World Health organization recommends publishing
-                        clinical trial results within one year after the end of a study.")
+allumc_clinicaltrials_trn_tooltip <- strwrap("This metric measures how many clinical trials with a journal publication
+                        report a trial registration number (TRN) in the abstract and in the
+                        full text of the publication. Reporting of TRNs in related publications
+                        facilitates transparent linkage between registration and publication.
+                        We developed open source R sripts to detect TRNs using a regular-expression-based
+                        approach. This analysis was limited to trials registered in
+                        ClinicalTrials.gov and/or DRKS for which a journal publication was found.
+                        The analysis was further restricted to publications indexed in PubMed
+                        (detection of TRN in abstract) and publications for which we could obtain
+                        the full text (detection of TRN in full text). More information can be found in the
+                              Methods page.")
 
-allumc_clinicaltrials_prereg_tooltip <- strwrap("This metric measures if the clinical trials are registered before the
-                        start date of the study, according to the information given on ClinicalTrials.gov.
-                        The idea of prospective registration of studies is to make the trial specifications,
-                        including primary and secondary outcomes, publicly available before study start.
-                        Prospective registration adds transparency, helps protect against outcome switching.")
+lim_allumc_clinicaltrials_trn_tooltip <- strwrap("The regular expressions detect any and all TRNs in an abstract and publication and do not distinguish
+                             between cases where a TRN is reported as a registration for the publication&#39s
+                             study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review, reference to other clinical trials, etc.).
+                             Finally, this analysis was limited to journal publications indexed in PubMed (TRN in abstract)
+                             and for which we could obtain the full text (TRN in full text).")
 
-allumc_clinicaltrials_timpub_tooltip5a <- strwrap("This metric measures how many clinical trials registered on ClinicalTrials.gov
-                        reported their results either as a journal publication or as summary results on the
-                        trials registry within 2 or 5 years after completion. Trials completed between 2009
-                        and 2013 were considered. The results were previously published as part of the
-                        IntoValue study (https://s-quest.bihealth.org/intovalue/). Clinical trials are expensive
-                        and often have many contributing patients. A fast dissemination of the trial results
-                        is crucial to make the evidence gained in those trials available. The World Health
-                        organization recommends publishing clinical trial results within one year after the
-                        end of a study.")
+allumc_linkage_tooltip <- strwrap("This metric measures links to the published journal article in clinical trial
+                             registry entries. Linking to the publication in the registration make results
+                             publication more findable and aids in evidence synthesis. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS for which a
+                             journal publication was found. The analysis was further restricted to publications
+                             with a DOI or that are indexed in PubMed. We queried the ClinicalTrials.gov and
+                             DRKS APIs to obtain linked publications in these registries. We considered a
+                             publication “linked” if the PMID or DOI was included in the trial registration.
+                                  More information can be found in the Methods page.")
 
-allumc_clinicaltrials_timpub_tooltip <- strwrap("This metric measures how many clinical trials registered on ClinicalTrials.gov
-                        reported their results either as a journal publication or as summary results on the
-                        trials registry within 2 or 5 years after completion. Trials completed between 2009
-                        and 2013 were considered. The results were previously published as part of the
-                        IntoValue study (https://s-quest.bihealth.org/intovalue/). Clinical trials are expensive
-                        and often have many contributing patients. A fast dissemination of the trial results
-                        is crucial to make the evidence gained in those trials available. The World Health
-                        organization recommends publishing clinical trial results within one year after the
-                        end of a study.")
+lim_allumc_linkage_tooltip <- strwrap("ClinicalTrials.gov includes a often-used
+                             PMID field for references. In addition, ClinicalTrials.gov automatically
+                             indexes publications from PubMed using TRN in the secondary identifier field.
+                             In contrast, DRKS includes references as a free-text field, leaving trialists
+                             to decide whether to enter any publication identifiers. Finally, this analysis
+                             was limited to trials with a journal publication which have a DOI or are
+                             indexed in PubMed.")
+
+allumc_clinicaltrials_sumres_tooltip <- strwrap("This metric measures how many clinical trials registered in EudraCT and
+                             that are due to report results in the EU Clinical Trials Register (EUCTR) have
+                             already done so. Interventional clinical trials using investigational medicinal
+                             products conducted in the EU/EEA are required to be registered in EudraCT.
+                             Sponsors of these trials are required to provide summary results within 12
+                             months of trial completion. Summary results reporting rates in EUCTR were
+                             retrieved from the EU Trials Tracker. Thus, the analysis was limited
+                             to trials listed in the EU Trials Tracker with a sponsor name corresponding
+                             to one of the UMCs presented here. Note that some trials
+                             registered in EudraCT and captured in this analysis may be cross-registered
+                             in ClinicalTrials.gov and/or DRKS. However, this plot displays summary results
+                             reporting only in EUCTR as listed in the EU Trials Tracker. More information
+                             can be found in the Methods page.")
+
+lim_allumc_clinicaltrials_sumres_tooltip <- strwrap("The EU Trials Tracker does not measure for how long trials have been due to
+                             report results. For UMCs with more than one corresponding sponsor name in the
+                             EU Trials Tracker, some trials may have been missed since we only selected
+                             maximum one sponsor name per UMC.")
+
+allumc_clinicaltrials_prereg_tooltip <- strwrap("This metric reflects whether a clinical trial was registered before the
+                        start date of the study. Prospective registration makes trial specifications,
+                        including primary and secondary outcomes, publicly available before study start,
+                        adds transparency and accountability, and helps protect against outcome switching.
+                        This analysis was limited to trials registered in
+                        ClinicalTrials.gov and/or DRKS with a start date given in the registry. To
+                        assess whether a study was prospectively registered, we compared the date
+                        the study was first submitted to the registry with the start date given in
+                        the registry. We defined a trial to be prospectively registered if the trial
+                        was registered in the same or a previous month to the trial start date, as
+                          some registrations provide only a start month rather than an exact date.
+                          More information can be found in the Methods page.")
+
+lim_allumc_clinicaltrials_prereg_tooltip <- strwrap("Trial registration was assessed for clinical trials registered in
+                             ClinicalTrials.gov and/or DRKS. We did not evaluate trials in further
+                             registries. The data presented relies on the information in registry
+                             entries being accurate and complete. Finally, trials without
+                             a start date in the registry were excluded from this analysis.")
+
+allumc_clinicaltrials_timpub_tooltip5a <- strwrap("This metric measures how many clinical trials in our dataset that
+                             reported results within 5 years of trial completion as (a) a
+                             journal publication and  (b) summary results in the registry.
+                             A fast dissemination of trial results is crucial to make the
+                             evidence gained in those trials available. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS.
+                             Both registries were searched for studies with one of the UMCs as
+                             the responsible party/sponsor or with a principal investigator from one of
+                             the UMCs. A manual search for published results was done, searching the
+                             registry, PubMed, and Google. If multiple results publications were found,
+                             only the earliest was included. Publication dates were manually entered during
+                             publication searches. When calculating the 5-year reporting
+                             rates, we only considered trials for which we had 5 years follow-up
+                             time since trial completion. The plot only displays data for
+                             completion years with more than 5 trials. More information can be found in the
+                              Methods page.")
+
+lim_allumc_clinicaltrials_timpub_tooltip5a <- strwrap("Only the earliest evidence of results reporting from trial completion
+                             was considered for both reporting of summary results in the registry and
+                             as a journal publication. Thus, the data presented
+                             does not reflect all result publications of a given trial. Moreover, some of
+                             the publications may have been missed in the manual search procedure as the
+                             search was restricted to a limited number of scientific databases and the 
+                             responsible parties were not contacted. Observational clinical studies were
+                             not included in this sample. The data presented relies on the information
+                             in registry entries being accurate and complete.")
+
+allumc_clinicaltrials_timpub_tooltip <- strwrap("This metric measures how many clinical trials in our dataset that
+                             reported results within 2 years of trial completion as (a) a
+                             journal publication and  (b) summary results in the registry.
+                             A fast dissemination of trial results is crucial to make the
+                             evidence gained in those trials available. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS.
+                             Both registries were searched for studies with one of the UMCs as
+                             the responsible party/sponsor or with a principal investigator from one of
+                             the UMCs. A manual search for published results was done, searching the
+                             registry, PubMed, and Google. If multiple results publications were found,
+                             only the earliest was included. Publication dates were manually entered during
+                             publication searches. When calculating the 2-year reporting
+                             rates, we only considered trials for which we had 2 years follow-up
+                             time since trial completion. More information can be found in the
+                              Methods page.")
+
+lim_allumc_clinicaltrials_timpub_tooltip <- strwrap("Only the earliest evidence of results reporting from trial completion
+                             was considered for both reporting of summary results in the registry and
+                             as a journal publication. Thus, the data presented
+                             does not reflect all result publications of a given trial. Moreover, some of
+                             the publications may have been missed in the manual search procedure as the
+                             search was restricted to a limited number of scientific databases and the 
+                             responsible parties were not contacted. Observational clinical studies were
+                             not included in this sample. The data presented relies on the information
+                             in registry entries being accurate and complete.")
 
 allumc_animal_rando_tooltip <- strwrap("This metric measures how many animal studies report a statement on
                             randomization of subjects into groups. Animal studies were identified using a
@@ -107,6 +207,10 @@ allumc_animal_rando_tooltip <- strwrap("This metric measures how many animal stu
                             PubMed Central corpus and which could be analyzed by SciScore are were included
                             in this analysis.")
 
+lim_allumc_animal_rando_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, randomization may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
+
+
+
 allumc_animal_blind_tooltip <- strwrap("This metric measures how many animal studies report a statement on whether
                             investigators were blinded to group assignment and/or outcome assessment. Animal
                             studies were identified using a previously published PubMed search filter. Reporting
@@ -115,12 +219,16 @@ allumc_animal_blind_tooltip <- strwrap("This metric measures how many animal stu
                             publications in the PubMed Central corpus and which could be analyzed by SciScore
                             are were included in this analysis.")
 
+lim_allumc_animal_blind_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, blinding may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
+
 allumc_animal_power_tooltip <- strwrap("This metric measures how many animal studies report a statement on sample size
                          calculation. Animal studies were identified using a previously published PubMed search
                          filter. Reporting of sample size calculation was evaluated with SciScore, an automated
                          tool which evaluates research articles based on their adherence to rigour and
                          reproducibility criteria. Only publications in the PubMed Central corpus and which
                          could be analyzed by SciScore are were included in this analysis.")
+
+lim_allumc_animal_power_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, sample size calculation may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
 
 #allumc_animal_iacuc_tooltip <- strwrap("This metric ...")
 
@@ -141,9 +249,10 @@ all_umcs_page <- tabPanel(
                     style = "margin-left: 0",
                     "This dashboard provides an overview of the performance of UMCs
                     in Germany on a set of practices relating to clinical research
-                    transparency. More detailed information on the underlying
-                    methods can be found by clicking on the methods and limitations
-                    widgets next to each plot, or by consulting the Methods page."
+                    transparency. On this page, you can view the data for all UMCs
+                    side-by-side. More detailed information on the underlying
+                    methods can be found in the methods and limitations widgets
+                    next to each plot, and in the Methods page."
                 ),
                 h4(style = "margin-left:0cm",
                    "The dashboard was developed as part of a scientific research

--- a/app.R
+++ b/app.R
@@ -128,14 +128,15 @@ server <- function (input, output, session) {
                        University Medical Centers (UMCs) in Germany. It displays
                        data relating to clinical trials conducted at UMCs
                        in Germany and completed between 2009 - 2017. Metrics
-                       included relate to the registration and reporting of these
+                       included refer to the registration and reporting of these
                        trials. With the exception of summary results reporting in
-                       EUCTR, the data in this dashboard relates to trials registered
-                       in ClinicalTrials.gov and/or DRKS. The dashboard was
-                       developed as part of a scientific research project with the
-                       overall aim to support the adoption of responsible research
-                       practices at UMCs. The dashboard is a pilot and continues
-                       to be updated. More metrics may be added in the future."),
+                       EUCTR, we focused on trials registered in ClinicalTrials.gov
+                       and/or the German Clinical Trials Registry (DRKS). The
+                       dashboard was developed as part of a scientific research
+                       project with the overall aim to support
+                       the adoption of responsible research practices at UMCs.
+                       The dashboard is a pilot and continues to be updated.
+                       More metrics may be added in the future."),
                     h4(style = "margin-left:0cm",
                        "The \"Start page\" displays the average data across all
                        included UMCs. The \"All UMCs\" page displays the data

--- a/app.R
+++ b/app.R
@@ -462,7 +462,7 @@ server <- function (input, output, session) {
             info_text = timpub_tooltip2,
             lim_id = "limTimPub2",
             lim_title = "Limitations: Timely Publication",
-            lim_text = lim_timpub_tooltip5
+            lim_text = lim_timpub_tooltip2
         )
     })
 
@@ -508,7 +508,7 @@ server <- function (input, output, session) {
             plot = plotlyOutput('plot_clinicaltrials_timpub_5a', height="300px"),
             info_id = "infoTimPub5",
             info_title = "Publication by 5 years",
-            info_text = timpub_tooltip2,
+            info_text = timpub_tooltip5,
             lim_id = "limTimPub5",
             lim_title = "Limitations: Timely Publication",
             lim_text = lim_timpub_tooltip5
@@ -958,10 +958,10 @@ server <- function (input, output, session) {
             plot = plotlyOutput('umc_plot_clinicaltrials_timpub_5a', height="300px"),
             info_id = "UMCinfoTimPub5",
             info_title = "Timely Publication (5 years)",
-            info_text = timpub_tooltip2,
+            info_text = timpub_tooltip5,
             lim_id = "UMClimTimPub5",
             lim_title = "Limitations: Timely Publication",
-            lim_text = lim_timpub_tooltip2
+            lim_text = lim_timpub_tooltip5
         )
     })
 

--- a/methods_page.R
+++ b/methods_page.R
@@ -12,7 +12,7 @@ methods_page <- tabPanel(
                        and/or the German Clinical Trials Registry (DRKS). The
                        dashboard was developed as part of a scientific research
                        project with the overall aim to support the adoption of
-            responsible research practices at UMCs.')),
+            responsible research practices at German UMCs.')),
                        
     h4(HTML('You can find more information on our methods for individual metrics
     by extending the panels below. You can also find a list of tools used for data
@@ -47,14 +47,12 @@ methods_page <- tabPanel(
                                dataset includes the results of both automated extractions
                                from registries (e.g., prospective registration) and
                                manual searches (e.g., timely reporting). The full IntoValue
-                               dataset is openly accessible on
+                               dataset is openly accessible at
                                <a href=https://zenodo.org/record/5141343#.YRJuSS0RrfY>Zenodo</a>.
                                More information on how this dataset was developed can
-                               be found in <a href=https://github.com/quest-bih/IntoValue2>GitHub</a>
-                               and in the publications associated with this IntoValue dataset
-                               (<a href=https://doi.org/10.1016/j.jclinepi.2019.06.002>IntoValue 1
+                               be found in the associated (<a href=https://doi.org/10.1016/j.jclinepi.2019.06.002>IntoValue 1
                                publication</a> and <a href=https://www.medrxiv.org/content/10.1101/2021.08.05.21261624v2
-                               >the follow-up IntoValue 2 study</a> now available as a pre-print).
+                               >the follow-up IntoValue 2 study</a> now available as a preprint).
                                <br>
                                <br>The IntoValue dataset was adapted in the following ways
                                for the development of this dashboard: (1) we extracted updated
@@ -84,31 +82,29 @@ methods_page <- tabPanel(
     bsCollapse(id = "methodsPanels_TrialRegistration",
                methods_panel("Prospective registration",
                              
-                             "This metric measures if a clinical trial is registered before the
+                             "This metric reflects whether a clinical trial was registered before the
                         start date of the study, according to the information given on ClinicalTrials.gov
                         and/or DRKS. Prospective registration makes trial specifications,
                         including primary and secondary outcomes, publicly available before study start,
-                        adds transparency and helps protect against outcome switching.",
+                        adds transparency and accountability, and helps protect against outcome switching.",
                              
                              "This analysis was limited to trials registered in ClinicalTrials.gov and/or
-                             DRKS with a start date given in the registry. To assess if a
+                             DRKS with a start date given in the registry. To assess whether a
                              study was prospectively registered, we compared the date the study was
                              first submitted to the registry with the start date given in the registry.
-                             As in some cases only the month rather than an exact date is provided in
-                             the registry, and to account for other possible delays, we defined a trial
-                             to be prospectively registered if the trial was registered in the
-                             same month or in a previous month to the trial start date.",
+                             We defined a trial to be prospectively registered if the trial was registered in the
+                             same or a previous month to the trial start date, as some registrstions provide only a start month rather than an exact date.",
                              
                              "Trial registration was assessed for clinical trials registered in
                              ClinicalTrials.gov and/or DRKS. We did not evaluate trials in further
                              registries. The data presented relies on the information in registry
                              entries being accurate and complete. Finally, trials without
-                             a start date in the registry were excluded from this analysis. "),
+                             a start date in the registry were excluded from this analysis."),
                
                methods_panel("Reporting of Trial Registration Number (TRN)",
                              
                              HTML("Reporting of clinical trial registration numbers (TRNs) in
-                             trial results publications facilitates transparent linkage between
+                             trial results publications facilitates transparent linking between
                              registration and publication. The <a 
                              href=https://www.sciencedirect.com/science/article/pii/S0140673607618352?via%3Dihub>
                              Consolidated Standards of Reporting Trials (CONSORT)</a>
@@ -119,28 +115,25 @@ methods_page <- tabPanel(
                              
                              HTML('We developed <a href="https://github.com/maia-sh/ctregistries">
                              open source R sripts</a> to detect TRNs. Our regular-expression-based
-                             algorithm searches text strings for matches to TRN patterns for all PubMed-indexed
+                             approach searches text strings for matches to TRN patterns for all PubMed-indexed
                              and ICTRP-network registries. More information on this package and its
-                             application can be found in this pre-print [enter DOI to TRN paper]. This
+                             application can be found in this preprint [enter DOI to TRN paper]. This
                              analysis was limited to trials registered in ClinicalTrials.gov and/or DRKS
                              for which a journal publication was found. The analysis was further restricted
                              to publications indexed in PubMed (detection of TRN in abstract) and
                              publications for which we could obtain the full text (detection of TRN in
-                             full text). We then applied the aforementioned algorithm to detect and
-                                  classify TRNs in the publication abstract and full text.'),
+                             full text).'),
                              
-                             HTML("The aforementioned algorithm does not distinguish true TRNs that do
-                             not resolve to a registration. Moreover, the algorithm does not distinguish
+                             HTML("The regular expressions detect any and all TRNs in an abstract and publication and do not distinguish
                              between cases where a TRN is reported as a registration for the publication&#39s
-                             study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review,
-                                  reference to other clinical trials, etc.). Finally, this analysis was
-                                  limited to journal publications indexed in PubMed (TRN in abstract)
-                                  and for which we could obtain the full text (TRN in full text).")),
+                             study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review, reference to other clinical trials, etc.).
+                             Finally, this analysis was limited to journal publications indexed in PubMed (TRN in abstract)
+                             and for which we could obtain the full text (TRN in full text).")),
                
                methods_panel("Linkage of journal publications in the registry",
                              
                              HTML("This metric measures links to the published journal article in clinical trial
-                             registry entries. Linking to the publication in the registration increases findability and
+                             registry entries. Linking to the publication in the registration make results publication more findable and
                              aids in evidence synthesis."),
                              
                              HTML('This analysis was limited to trials registered in ClinicalTrials.gov and/or
@@ -148,15 +141,15 @@ methods_page <- tabPanel(
                              restricted to publications with a DOI or that are indexed in PubMed. We
                              queried the ClinicalTrials.gov and DRKS APIs (May 2021) to obtain
                              linked publications in these registries. We considered a publication “linked”
-                                  if the PMID or DOI was included in the trial registration.'),
+                             if the PMID or DOI was included in the trial registration.'),
                              
                              HTML("<i>Registry limitations:</i> ClinicalTrials.gov includes a often-used
                              PMID field for references. In addition, ClinicalTrials.gov automatically
                              indexes publications from PubMed using TRN in the secondary identifier field.
                              In contrast, DRKS includes references as a free-text field, leaving trialists
                              to decide whether to enter any publication identifiers. Finally, this analysis
-                                  was limited to trials with a journal publication which have a DOI or are
-                                  indexed in PubMed"))),
+                             was limited to trials with a journal publication which have a DOI or are
+                             indexed in PubMed"))),
     
     h3("Trial Reporting"),
     bsCollapse(id = "methodsPanels_TrialReporting",
@@ -188,10 +181,10 @@ methods_page <- tabPanel(
                              corresponding sponsor name was found for a given UMC, we only selected the 
                              sponsor name with the most trials. The list of selected sponsor names can be 
                              found <a href=https://github.com/quest-bih/clinical-dashboard/blob/main/prep/eutt-sponsors-of-interest.csv
-                                  >here</a>. Note that some trials registered in EudraCT and captured in
-                                  this analysis may be cross-registered in ClinicalTrials.gov and/or DRKS.
-                                  However, this plot only displays summary results reporting in EUCTR as
-                                  listed in the EU Trials Tracker.'),
+                             >here</a>. Note that some trials registered in EudraCT and captured in
+                             this analysis may be cross-registered in ClinicalTrials.gov and/or DRKS.
+                             However, this plot displays summary results reporting only in EUCTR as
+                             listed in the EU Trials Tracker.'),
                              
                              "The EU Trials Tracker does not measure for how long trials have been due to
                              report results. For UMCs with more than one corresponding sponsor name in the
@@ -214,7 +207,7 @@ methods_page <- tabPanel(
                              <a href=https://www.sciencedirect.com/science/article/abs/pii/S0895435618310631?via%3Dihub>
                              IntoValue 1 study</a> and the follow-up 
                              <a href=https://www.medrxiv.org/content/10.1101/2021.08.05.21261624v2>
-                             IntoValue 2 study</a> (available as a pre-print). This analysis was limited
+                             IntoValue 2 study</a> (available as a preprint). This analysis was limited
                              to trials registered in ClinicalTrials.gov and/or DRKS. Both registries were
                              searched for studies with one of the UMCs as
                              the responsible party/sponsor or with a principal investigator from one of
@@ -253,12 +246,9 @@ methods_page <- tabPanel(
                              to maximise the value and impact of research discoveries. This metric measures
                              the OA status of publications in our sample.",
                              
-                             HTML('This analysis was limited to trials with a journal publication for which
-                             a DOI has been assigned. Using this set of publications as basis, we queried the
-                        Unpaywall database via its <a href="https://unpaywall.org/products/api">API</a>
-                        to obtain information on the OA status of publications. Unpaywall is today the
-                        most comprehensive database of OA information on research articles. It can be queried
-                        using publication DOIs. Publications can have different OA statuses which are
+                             HTML('This analysis was limited to trials with a journal publication and
+                             a DOI. We queried the Unpaywall database via its <a href="https://unpaywall.org/products/api">API</a>
+                        to obtain information on the OA status of publications. Publications can have different OA statuses which are
                         color-coded. Gold OA denotes a publication in an OA journal. Green OA denotes a
                         freely available repository version. Hybrid OA denotes an OA publication in a journal
                         which offers both a subscription based model as well as an OA option. The category
@@ -267,23 +257,20 @@ methods_page <- tabPanel(
                         have been made available voluntarily by the journal, but which might at some stage
                         lose their OA status again. We only considered the following categories as OA in this
                         dashboard: Gold OA, Green OA, and Hybrid OA. As a publication can have several OA
-                        versions (e.g. a gold version in an OA journal as well as a green version in a repository),
+                        versions (e.g., a gold version in an OA journal as well as a green version in a repository),
                         we define a hierarchy for the OA categories and for each publication only assign the
                         OA category with the highest priority. We use a hierarchy of gold - hybrid - green
                         (journal version before repository version), as also implemented in the Unpaywall
-                        database itself. After querying the Unpaywall API for all publication DOIs, we
-                        group the results by OA status.
+                        database itself.
                         <br>
-                        <br>One important point that has to be considered with OA data is that
-                        the OA percentage is not a fixed number, but changes over time. This is due to the fact
-                        that repository versions are often made available with a delay, such that the OA
-                        percentage for a given year typically rises retrospectively. Thus, the point in time
+                        <br>OA status is not fixed but rather changes over time, as repository versions are often made available with a delay.
+                        Therefore, the OA percentage for a given year typically rises retrospectively. Thus, the point in time
                         at which the OA status is retrieved is important for the OA percentage. The current
                         OA data was retrieved with <a href="https://github.com/NicoRiedel/unpaywallR">
                              UnpaywallR</a> on: 15/07/2021.'),
                              
                              "Unpaywall only stores information for publications which have a DOI assigned by
-                        Crossref. Articles without a Crossref DOI have to be excluded from the OA analysis."),
+                        Crossref. Articles without a Crossref DOI were therefore excluded from the OA analysis."),
                
                methods_panel("Potential Green Open Access",
                              
@@ -300,8 +287,8 @@ methods_page <- tabPanel(
                              delay. This metric measures how many paywalled publications with the potential
                              for green OA have been made available via this route."),
                              
-                             HTML('This analysis was limited to trials with a journal publication for which
-                             a DOI has been assigned. In a first step, we identified publications which are
+                             HTML('This analysis was limited to trials with a journal publication with a DOI.
+                             In a first step, we identified publications which are
                              only accessible in a repository (Green OA only). To do so, we queried the
                              Unpaywall API (with <a href="https://github.com/NicoRiedel/unpaywallR">
                              UnpaywallR</a>) with the following hierarchy: gold - hybrid - bronze - green - 
@@ -317,11 +304,11 @@ methods_page <- tabPanel(
                              the publication; (3) this permission relates to archiving in an institutional repository;
                              and (4) the embargo linked to this permission had elapsed (if applicable). we did
                              not consider permissions relating to the submitted version. The Unpaywall database
-                                  was queried on 15/07/2021. The Shareyourpaper permissions API was queried on
-                                  23/07/2021.'),
+                             was queried on 15/07/2021. The Shareyourpaper permissions API was queried on
+                             23/07/2021.'),
                              
-                             "Not all publications queried were resolved in Unpaywall and ShareYourPaper. We also
-                             only extracted permissions data for publications which have a \"best permission\"
+                             "Not all queried publications resolved in Unpaywall and ShareYourPaper. We also
+                             extracted permissions data only for publications which have a \"best permission\"
                              in the Shareyourpaper.org database. The date at which a publication can be made
                              openly accessible via self-archiving depends on the publication date and the
                              length of the embargo (if any). Therefore, the number of paywalled publications

--- a/methods_page.R
+++ b/methods_page.R
@@ -6,30 +6,77 @@ methods_page <- tabPanel(
                        University Medical Centers (UMCs) in Germany. It displays
                        data relating to clinical trials conducted at UMCs
                        in Germany and completed between 2009 - 2017. Metrics
-                       included relate to the registration and reporting of these
+                       included refer to the registration and reporting of these
                        trials. With the exception of summary results reporting in
-                       EUCTR, the data in this dashboard relates to trials registered
-                       in ClinicalTrials.gov and/or DRKS. The dashboard was
-                       developed as part of a scientific research project with the
-                       overall aim to support the adoption of responsible research
-                       practices at UMCs.')),
+                       EUCTR, we focused on trials registered in ClinicalTrials.gov
+                       and/or the German Clinical Trials Registry (DRKS). The
+                       dashboard was developed as part of a scientific research
+                       project with the overall aim to support the adoption of
+            responsible research practices at UMCs.')),
                        
     h4(HTML('You can find more information on our methods for individual metrics
     by extending the panels below. You can also find a list of tools used for data
-            collection at the bottom of this page.')),
+            collection at the bottom of this page. The \"FAQ\" and \"Why these
+            metrics?\" pages provide more general information about this dashboard
+            and our selection of metrics."')),
+    
+    h4(style = "margin-left:0cm; color: purple",
+       HTML("More information on the overall aim and methodology can be
+                       found in the publication asssociated with this dashboard
+            [enter DOI]. ")),
     
     h3("Identification of clinical trials"),
     bsCollapse(id = "methodsPanels_IdentificationTrials",
                bsCollapsePanel(strong("Identification of clinical trials"),
-                               p(HTML("The dashboard displays data relating to clinical
-                               trials conducted at German UMCs and completed between
-                                      2009 - 2017. The underlying dataset is openly
-                                      accessible on <a href=https://zenodo.org/record/5141343#.YRJuSS0RrfY>Zenodo</a>.
-                                      All UMCs were included except for Bielefeld, which was founded after the start
-                                      of data collection. The data in this dashboard differs from this dataset in
-                                      the following ways: (a) we queried updated data from ClinicalTrials.gov and
-                                      DRKS in May 2021; (b) summary results dates for trials registered in DRKS
-                                      were extracted manually from the registry based on the change history.")),
+                               p(HTML("With the exception of summary results
+                               reporting in EUCTR, the data presented in this
+                               dashboard is based on a previously developed dataset,
+                               IntoValue. This dataset contains data on clinical
+                               trials conducted at one of 35 German UMCs and registered
+                               on ClinicalTrials.gov and/or the German Clinical Trials
+                               Registry (DRKS). Trials were associated with a German UMC
+                               by searching these registries for trials with a UMC listed as responsible
+                               party or lead sponsor, or with a principle investigator (PI)
+                               from a UMC. Trials include all interventional
+                               studies and are not limited to investigational medical
+                               product trials, as regulated by the EU's Clinical Trials
+                               Directive or Germany's Arzneimittelgesetz (AMG) or Novelle
+                               des Medizinproduktegesetzes (MPG). All trials were
+                               reported as complete between 2009 and 2017 on the
+                               trial registry at the time of data collection. The
+                               dataset includes the results of both automated extractions
+                               from registries (e.g., prospective registration) and
+                               manual searches (e.g., timely reporting). The full IntoValue
+                               dataset is openly accessible on
+                               <a href=https://zenodo.org/record/5141343#.YRJuSS0RrfY>Zenodo</a>.
+                               More information on how this dataset was developed can
+                               be found in <a href=https://github.com/quest-bih/IntoValue2>GitHub</a>
+                               and in the publications associated with this IntoValue dataset
+                               (<a href=https://doi.org/10.1016/j.jclinepi.2019.06.002>IntoValue 1
+                               publication</a> and <a href=https://www.medrxiv.org/content/10.1101/2021.08.05.21261624v2
+                               >the follow-up IntoValue 2 study</a> now available as a pre-print).
+                               <br>
+                               <br>The IntoValue dataset was adapted in the following ways
+                               for the development of this dashboard: (1) we extracted updated
+                               registry data from ClinicalTrials.gov and DRKS in
+                               May 2021; (2) summary results reporting for trials
+                               registered in DRKS was extracted manually from the
+                               registry using the registry's change history; (3)
+                               we included additional information on the reporting
+                               of trial registration numbers in trial results
+                               publications, publication linkage in the registry,
+                               and Open Access; (4) while the original IntoValue
+                               dataset considered both journal publications and
+                               dissertations as results publications, we focused
+                               on journal publications in this dashboard. More
+                               information on how the IntoValue dataset was adapted
+                               for use in this dashboard can be found in the
+                               <a href=https://github.com/maia-sh/intovalue-data>
+                               associated code repository in GitHub</a>.<br>
+                               
+                               <br>The following German UMCs are not currently included
+                               in this dashboard: Augsburg, Bielefeld, and Oldenburg. These
+                               UMCs were founded after the start of data collection.")),
                                value = "methodsPanels_IdentificationTrials",
                                style = "default")),
     
@@ -38,27 +85,31 @@ methods_page <- tabPanel(
                methods_panel("Prospective registration",
                              
                              "This metric measures if a clinical trial is registered before the
-                        start date of the study, according to the information given on ClinicalTrials.gov and/or DRKS.
-                        Prospective registration allows the trial specifications,
+                        start date of the study, according to the information given on ClinicalTrials.gov
+                        and/or DRKS. Prospective registration helps to make trial specifications,
                         including primary and secondary outcomes, publicly available before study start.
                         Prospective registration adds transparency and helps protect against outcome switching.",
                              
-                             "To assess if a study has been prospectively registered, we compare
-                        the date the study was first submitted to the registry with the
-                        start date given in the registry. As some of the earlier dates in the registries
-                        only state the month rather than an exact day and to account for other possible delays,
-                        we defined a trial to be prospectively registered if the trial was registered in the
+                             "This analysis was limited to trials registered in ClinicalTrials.gov and/or
+                             DRKS with a start date given in the registry. To assess if a
+                             study was prospectively registered, we compared the date the study was
+                             first submitted to the registry with the start date given in the registry.
+                             As in some cases only the month rather than an exact date is provided in
+                             the registry, and to account for other possible delays, we defined a trial
+                             to be prospectively registered if the trial was registered in the
                              same month or in a previous month to the trial start date.",
                              
-                             "Trial registration was assessed for clinical trials registered in ClinicalTrials.gov
-                             and/or DRKS. The data presented depends on the information on ClinicalTrials.gov and
-                             DRKS being accurate. Trials without a start date in the registry were excluded from
-                             this analysis. We did not evaluate trials registered in other registries."),
+                             "Trial registration was assessed for clinical trials registered in
+                             ClinicalTrials.gov and/or DRKS. We did not evaluate trials in further
+                             registries. The data presented relies on the information in registry
+                             entries being accurate and complete. Finally, trials without
+                             a start date in the registry were excluded from this analysis. "),
                
                methods_panel("Reporting of Trial Registration Number (TRN)",
                              
-                             HTML("Reporting of clinical trial registration numbers (TRNs) in related publications
-                             facilitates transparent linkage between registration and publication. The <a 
+                             HTML("Reporting of clinical trial registration numbers (TRNs) in
+                             trial results publications facilitates transparent linkage between
+                             registration and publication. The <a 
                              href=https://www.sciencedirect.com/science/article/pii/S0140673607618352?via%3Dihub>
                              Consolidated Standards of Reporting Trials (CONSORT)</a>
                              as well as the <a href=http://www.icmje.org/recommendations/>ICMJE Recommendations
@@ -66,101 +117,125 @@ methods_page <- tabPanel(
                              Journals</a> call for reporting <i>&#39trial registration number and name of the
                              trial register&#39</i> in both the full-text and abstract."),
                              
-                             HTML('We developed an <a href="https://github.com/maia-sh/ctregistries">open source R
-                                  package</a> to detect clinical TRNs. Our regular-expression-based
-                                  algorithm searches text strings for matches to TRN patterns for all PubMed-indexed
-                                  and ICTRP-network registries. We limited this analysis to trials with a journal
-                                  publication. We further filtered this subset for publications
-                                  indexed in PubMed (detection of TRN in abstract) and for publications for which
-                                  we could obtain the full text (detection of TRN in full text). We then applied the
-                                  aforementioned package to detect and classify TRNs in the publication abstract
-                                  and full text.'),
+                             HTML('We developed <a href="https://github.com/maia-sh/ctregistries">
+                             open source R sripts</a> to detect clinical TRNs. Our regular-expression-based
+                             algorithm searches text strings for matches to TRN patterns for all PubMed-indexed
+                             and ICTRP-network registries. More information on this package and its
+                             application can be found in this pre-print [enter DOI to TRN paper]. This
+                             analysis was limited to trials registered in ClinicalTrials.gov and/or DRKS
+                             for which a journal publication was found. The analysis was further restricted
+                             to publications indexed in PubMed (detection of TRN in abstract) and
+                             publications for which we could obtain the full text (detection of TRN in
+                             full text). We then applied the aforementioned algorithm to detect and
+                                  classify TRNs in the publication abstract and full text.'),
                              
-                             HTML("Our algorithm does not distinguish true TRNs that do not resolve to a registration.
-                             Moreover, the algorithm does not distinguish between cases where a TRN is reported as a
-                             registration for the publication&#39s study (i.e., clinical trial result) or is otherwise
-                                  mentioned (i.e., in a review, reference to other clinical trials, etc.)")),
+                             HTML("The aforementioned algorithm does not distinguish true TRNs that do
+                             not resolve to a registration. Moreover, the algorithm does not distinguish
+                             between cases where a TRN is reported as a registration for the publication&#39s
+                             study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review,
+                                  reference to other clinical trials, etc.). Finally, this analysis was
+                                  limited to journal publications indexed in PubMed (TRN in abstract)
+                                  and for which we could obtain the full text (TRN in full text).")),
                
                methods_panel("Linkage of journal publications in the registry",
                              
                              HTML("Linking to the publication in the registration increases findability and
                                   threaded evidence."),
                              
-                             HTML('We queried the ClinicalTrials.gov and DRKS APIs (May 2021) to obtain publication
-                             links in these registries. We limited this analysis to trials with a journal publication
-                             with a DOI and/or indexed in PubMed. We considered a publication “linked” if the PMID
-                             or DOI was included in the trial registration. Note that some publications are included
-                             in a registration without a PMID or DOI (i.e., publication title and/or URL only).'),
+                             HTML('This analysis was limited to trials registered in ClinicalTrials.gov and/or
+                             DRKS for which a journal publication was found. The analysis was further
+                             restricted to publications with a DOI or that are indexed in PubMed. We
+                             queried the ClinicalTrials.gov and DRKS APIs (May 2021) to obtain
+                             linked publications in these registries. We considered a publication “linked”
+                                  if the PMID or DOI was included in the trial registration.'),
                              
-                             HTML("<i>Registry limitations:</i> ClinicalTrials.gov includes a often-used PMID field
-                             for references. In addition, ClinicalTrials.gov automatically indexes publications from
-                             PubMed using TRN in the secondary identifier field. In contrast, DRKS includes references
-                             as a free-text field, leaving trialists to decide whether to enter any publication
-                                  identifiers."))),
+                             HTML("<i>Registry limitations:</i> ClinicalTrials.gov includes a often-used
+                             PMID field for references. In addition, ClinicalTrials.gov automatically
+                             indexes publications from PubMed using TRN in the secondary identifier field.
+                             In contrast, DRKS includes references as a free-text field, leaving trialists
+                             to decide whether to enter any publication identifiers. Finally, this analysis
+                                  was limited to trials with a journal publication which have a DOI or are
+                                  indexed in PubMed"))),
     
     h3("Trial Reporting"),
     bsCollapse(id = "methodsPanels_TrialReporting",
                methods_panel("Summary results reporting in EUCTR",
                              
-                             HTML("This metric measures how many clinical trials registered in EudraCT and that are
-                             due to report their results in the EU Clinical Trials Register (EUCTR) have already
-                             done so. Interventional clinical trials using investigational medicinal products
-                             conducted in the EU/EEA are required to be registered in EudraCT. According to the
-                             <a href=https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52012XC1006(01)&from=EN>
-                             Commission guideline 2012/C 302/03</a>, sponsors of these trials are required to provide
-                             summary results within 12 months of trial completion. Clinical trials are expensive
-                             and have often many contributing patients. A fast dissemination of the trial results
-                             is crucial to make the evidence gained in those trials available. Beyond EU-level
-                             requirements, the World Health Organization recommends publishing summary results
-                             in the registry within 12 months of trial completion."),
+                             HTML("This metric measures how many clinical trials registered in EudraCT and
+                             that are due to report results in the EU Clinical Trials Register (EUCTR) have
+                             already done so. Interventional clinical trials using investigational medicinal
+                             products conducted in the EU/EEA are required to be registered in EudraCT.
+                             According to the <a href=https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52012XC1006(01)&from=EN>
+                             Commission guideline 2012/C 302/03</a>, sponsors of these trials are required
+                             to provide summary results within 12 months of trial completion. Clinical trials
+                             are expensive and have often many contributing patients. A fast dissemination
+                             of the trial results is crucial to make the evidence gained in those trials
+                             available. Beyond EU-level requirements, the
+                             <a href=https://www.who.int/news/item/18-05-2017-joint-statement-on-registration>
+                             World Health Organization</a> recommends publishing summary results in the
+                             registry within 12 months of trial completion."),
                              
-                             HTML('Summary results reporting rate in EUCTR were retrieved from the
-                        <a href="https://eu.trialstracker.net">EU Trials Tracker</a> by the EBM DataLab. For
-                                  each UMC in our dataset, we searched the corresponding sponsor name in the
-                                  EU Trials Tracker. With the exception of one UMC (Mannheim), we found at least
-                                  one sponsor name for each UMC in the EU Trials Tracker. If more than one
-                                  corresponding sponsor name was found for a given UMC, we only selected the
-                                  sponsor name was with the most trials. The list of selected sponsor names
-                                  can be found <a href=https://github.com/quest-bih/clinical-dashboard/blob/main/prep/eutt-sponsors-of-interest.csv
-                                  >here</a>.'),
+                             HTML('This analysis is limited to trials listed in the
+                             <a href="https://eu.trialstracker.net">EU Trials Tracker</a> (and therefore
+                             registered in EudraCT) with a sponsor name corresponding to one of the UMCs
+                             included in this dashboard. Summary results reporting rates in EUCTR were
+                             retrieved from the EU Trials Tracker&#39s (EBM DataLab) 
+                             <a href=https://github.com/ebmdatalab/euctr-tracker-data>code repository</a>.
+                             For each UMC in our dataset, we searched the corresponding sponsor name in the
+                             EU Trials Tracker. With the exception of one UMC (Mannheim), we found at least
+                             one sponsor name for each UMC in the EU Trials Tracker. If more than one 
+                             corresponding sponsor name was found for a given UMC, we only selected the 
+                             sponsor name with the most trials. The list of selected sponsor names can be 
+                             found <a href=https://github.com/quest-bih/clinical-dashboard/blob/main/prep/eutt-sponsors-of-interest.csv
+                                  >here</a>. Note that some trials registered in EudraCT and captured in
+                                  this analysis may be cross-registered in ClinicalTrials.gov and/or DRKS.
+                                  However, this plot only displays summary results reporting in EUCTR as
+                                  listed in the EU Trials Tracker.'),
                              
-                             "The EU Trials Tracker does not measure for how long the trials have
-                             been due. Some trials registered in EudraCT may also registered in ClinicalTrials.gov
-                             and/or DRKS. However, this plot only displays summary results reporting in
-                             EUCTR as determined by the EU Trials Tracker."),
+                             "The EU Trials Tracker does not measure for how long trials have been due to
+                             report results. For UMCs with more than one corresponding sponsor name in the
+                             EU Trials Tracker, some trials may have been missed since we only selected
+                             maximum one sponsor name per UMC."),
                
                methods_panel("Results reporting (2-year and 5-year reporting)",
                              
-                             HTML("This metric measures how many clinical trials in our dataset that are registered in
-                             ClinicalTrials.gov and/or DRKS reported results as (a) a journal publication or
-                             (b) summary results in the registry within 2 and 5 years of trial completion. A fast
-                        dissemination of the trial results is crucial to make the evidence gained
-                        in those trials available. The <a href=https://www.who.int/news/item/18-05-2017-joint-statement-on-registration>
+                             HTML("This metric measures how many clinical trials in our dataset that
+                             are registered in ClinicalTrials.gov and/or DRKS reported results within
+                             2 and 5 years of trial completion as (a) a journal publication and 
+                             (b) summary results in the registry. A fast dissemination of trial
+                             results is crucial to make the evidence gained in those trials available.
+                             The <a href=https://www.who.int/news/item/18-05-2017-joint-statement-on-registration>
                         World Health Organization</a> recommends publishing registry summary results within
                         12 months and a publication within 24 months of trial completion."),
                              
-                             HTML('ClinicalTrials.gov and DRKS.de were searched for studies with one of the UMCs
-                             as the responsible party/sponsor or with a principal investigator from one of the
-                             UMCs. A manual search for published results was done, searching the
-                        registry, PubMed, and Google. When calculating the 2-year and 5-year reporting rates,
-                        we only considered trials for which we had 2 and 5 years follow-up time since trial
-                        completion, respectively. The results were previously
-                        published as part of the <a href=https://www.sciencedirect.com/science/article/abs/pii/S0895435618310631?via%3Dihub>
-                        IntoValue 1 study</a>. A follow-up study, <a href=https://www.medrxiv.org/content/10.1101/2021.08.05.21261624v2>
-                        IntoValue 2</a>, is now available as a pre-print.'),
+                             HTML('This data is the result of automated and manual searches and was
+                             previously published as part of the 
+                             <a href=https://www.sciencedirect.com/science/article/abs/pii/S0895435618310631?via%3Dihub>
+                             IntoValue 1 study</a> and the follow-up 
+                             <a href=https://www.medrxiv.org/content/10.1101/2021.08.05.21261624v2>
+                             IntoValue 2 study</a> (available as a pre-print). This analysis was limited
+                             to trials registered in ClinicalTrials.gov and/or DRKS. Both registries were
+                             searched for studies with one of the UMCs as
+                             the responsible party/sponsor or with a principal investigator from one of
+                             the UMCs. A manual search for published results was done, searching the
+                             registry, PubMed, and Google. If multiple results publications were found,
+                             the earliest was included. When calculating the 2-year and 5-year reporting
+                             rates, we only considered trials for which we had 2 and 5 years follow-up
+                             time since trial completion, respectively.'),
                              
-                             HTML("We only considered the earliest evidence of results reporting from trial completion (as
-                             either reporting of summary results in the registry or as a journal publication). The data
-                             presented in this dashboard therefore does not reflect all result publications of a given
-                             trial. Moreover, some of the publications may have been missed in the manual search 
-                             procedure as we only searched a limited number of scientific databases and did not 
-                             contact the responsible parties. We did not include observational clinical studies in
-                             our sample. Finally, we might overestimate the time to publication for some studies
-                             as we stopped the manual search after the first detected publication. <i>Further
-                             registry limitations</i>: ClinicalTrials.gov includes a structured summary results field. In contrast,
-                             DRKS includes summary results with other references, and summary results were inferred
-                             based on keywords, such as \"Ergebnisbericht\" or \"Abschlussbericht\", in the reference
-                             title."))),
+                             HTML("Only the earliest evidence of results reporting from trial completion
+                             was considered for both reporting of summary results in the registry and
+                             as a journal publication. The data presented in this dashboard therefore
+                             does not reflect all result publications of a given trial. Moreover, some of
+                             the publications may have been missed in the manual search procedure as the
+                             search was restricted to a limited number of scientific databases and the 
+                             responsible parties were not contacted. Observational clinical studies were
+                             not included in this sample. <i>Further registry limitations</i>:
+                             ClinicalTrials.gov includes a structured summary results field. In contrast,
+                             DRKS includes summary results with other references, and summary results were
+                             inferred based on keywords, such as \"Ergebnisbericht\" or \"Abschlussbericht\",
+                             in the reference title. The data presented relies on the information in registry
+                             entries being accurate and complete."))),
     
     hr(),
     h3("Open Access"),
@@ -249,12 +324,21 @@ methods_page <- tabPanel(
                              openly accessible via self-archiving depends on the publication date and the
                              length of the embargo (if any). Therefore, the number of paywalled publications
                              with the potential for green OA will change over time.")),
+    
+    h3("Dashboard development"),
+    bsCollapse(id = "methodsPanels_DashboardDevelopment",
+               bsCollapsePanel(strong("Dashboard development"),
+                               p(HTML("The dashboard was developed using the Shiny R package
+                               (version 1.6.0). The <a href=https://github.com/quest-bih/clinical-dashboard
+                                      >underlying code</a> is openly available in GitHub under
+                                      an AGPL license and may be adapted for further use."),
+                               style = "default"))),
                    
     h3("Tools used for data collection"),
     helpText(HTML('<a href="https://github.com/NicoRiedel/unpaywallR"> UnpaywallR </a>')),
     helpText(HTML('<a href="https://shareyourpaper.org/permissions/about">
                   ShareYourPaper permissions checker API</a> from OA.Works')),
-    helpText(HTML('<a href="https://github.com/maia-sh/ctregistries"> ctregistries R package </a>')),
+    helpText(HTML('<a href="https://github.com/maia-sh/ctregistries">ctregistries repository</a>')),
     helpText(HTML('<a href="https://eu.trialstracker.net/">EU Trials Tracker </a>'))
 )
 

--- a/methods_page.R
+++ b/methods_page.R
@@ -86,9 +86,9 @@ methods_page <- tabPanel(
                              
                              "This metric measures if a clinical trial is registered before the
                         start date of the study, according to the information given on ClinicalTrials.gov
-                        and/or DRKS. Prospective registration helps to make trial specifications,
-                        including primary and secondary outcomes, publicly available before study start.
-                        Prospective registration adds transparency and helps protect against outcome switching.",
+                        and/or DRKS. Prospective registration makes trial specifications,
+                        including primary and secondary outcomes, publicly available before study start,
+                        adds transparency and helps protect against outcome switching.",
                              
                              "This analysis was limited to trials registered in ClinicalTrials.gov and/or
                              DRKS with a start date given in the registry. To assess if a
@@ -118,7 +118,7 @@ methods_page <- tabPanel(
                              trial register&#39</i> in both the full-text and abstract."),
                              
                              HTML('We developed <a href="https://github.com/maia-sh/ctregistries">
-                             open source R sripts</a> to detect clinical TRNs. Our regular-expression-based
+                             open source R sripts</a> to detect TRNs. Our regular-expression-based
                              algorithm searches text strings for matches to TRN patterns for all PubMed-indexed
                              and ICTRP-network registries. More information on this package and its
                              application can be found in this pre-print [enter DOI to TRN paper]. This
@@ -139,8 +139,9 @@ methods_page <- tabPanel(
                
                methods_panel("Linkage of journal publications in the registry",
                              
-                             HTML("Linking to the publication in the registration increases findability and
-                                  threaded evidence."),
+                             HTML("This metric measures links to the published journal article in clinical trial
+                             registry entries. Linking to the publication in the registration increases findability and
+                             aids in evidence synthesis."),
                              
                              HTML('This analysis was limited to trials registered in ClinicalTrials.gov and/or
                              DRKS for which a journal publication was found. The analysis was further
@@ -168,7 +169,7 @@ methods_page <- tabPanel(
                              According to the <a href=https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52012XC1006(01)&from=EN>
                              Commission guideline 2012/C 302/03</a>, sponsors of these trials are required
                              to provide summary results within 12 months of trial completion. Clinical trials
-                             are expensive and have often many contributing patients. A fast dissemination
+                             are expensive and have often many contributing patients. Timely dissemination
                              of the trial results is crucial to make the evidence gained in those trials
                              available. Beyond EU-level requirements, the
                              <a href=https://www.who.int/news/item/18-05-2017-joint-statement-on-registration>
@@ -249,7 +250,8 @@ methods_page <- tabPanel(
                              research articles accelerates and broadens the dissemination of research discoveries.
                              OA also enables greater visibility of research and makes it easier to build
                              on existing knowledge. Research funders are increasingly encouraging OA
-                             to maximise the value and impact of research discoveries.",
+                             to maximise the value and impact of research discoveries. This metric measures
+                             the OA status of publications in our sample.",
                              
                              HTML('This analysis was limited to trials with a journal publication for which
                              a DOI has been assigned. Using this set of publications as basis, we queried the

--- a/methods_page.R
+++ b/methods_page.R
@@ -93,7 +93,8 @@ methods_page <- tabPanel(
                              study was prospectively registered, we compared the date the study was
                              first submitted to the registry with the start date given in the registry.
                              We defined a trial to be prospectively registered if the trial was registered in the
-                             same or a previous month to the trial start date, as some registrstions provide only a start month rather than an exact date.",
+                             same or a previous month to the trial start date, as some registrations provide
+                             only a start month rather than an exact date.",
                              
                              "Trial registration was assessed for clinical trials registered in
                              ClinicalTrials.gov and/or DRKS. We did not evaluate trials in further
@@ -103,9 +104,10 @@ methods_page <- tabPanel(
                
                methods_panel("Reporting of Trial Registration Number (TRN)",
                              
-                             HTML("Reporting of clinical trial registration numbers (TRNs) in
-                             trial results publications facilitates transparent linking between
-                             registration and publication. The <a 
+                             HTML("This metric measures how many clinical trials with a journal publication
+                             report a trial registration number (TRN) in the abstract and in the
+                             full text of the publication. Reporting of TRNs in trial results publications
+                             facilitates transparent linking between registration and publication. The <a 
                              href=https://www.sciencedirect.com/science/article/pii/S0140673607618352?via%3Dihub>
                              Consolidated Standards of Reporting Trials (CONSORT)</a>
                              as well as the <a href=http://www.icmje.org/recommendations/>ICMJE Recommendations
@@ -181,10 +183,13 @@ methods_page <- tabPanel(
                              corresponding sponsor name was found for a given UMC, we only selected the 
                              sponsor name with the most trials. The list of selected sponsor names can be 
                              found <a href=https://github.com/quest-bih/clinical-dashboard/blob/main/prep/eutt-sponsors-of-interest.csv
-                             >here</a>. Note that some trials registered in EudraCT and captured in
-                             this analysis may be cross-registered in ClinicalTrials.gov and/or DRKS.
-                             However, this plot displays summary results reporting only in EUCTR as
-                             listed in the EU Trials Tracker.'),
+                             >here</a>. While the EU Trials Tracker is usually updated on a monthly basis,
+                             in some cases there was more than one update within the same month. In these
+                             cases, only the latest data point within that month is displayed. Note that
+                             some trials registered in EudraCT and captured in this analysis may be
+                             cross-registered in ClinicalTrials.gov and/or DRKS. However, this plot
+                             displays summary results reporting only in EUCTR as listed in the EU Trials
+                                  Tracker.'),
                              
                              "The EU Trials Tracker does not measure for how long trials have been due to
                              report results. For UMCs with more than one corresponding sponsor name in the
@@ -213,9 +218,11 @@ methods_page <- tabPanel(
                              the responsible party/sponsor or with a principal investigator from one of
                              the UMCs. A manual search for published results was done, searching the
                              registry, PubMed, and Google. If multiple results publications were found,
-                             the earliest was included. When calculating the 2-year and 5-year reporting
+                             the earliest was included. Publication dates were manually entered during
+                             publication searches. When calculating the 2-year and 5-year reporting
                              rates, we only considered trials for which we had 2 and 5 years follow-up
-                             time since trial completion, respectively. Publication dates were manually entered during publication searches.'),
+                             time since trial completion, respectively. The plot only displays data for
+                             completion years with more than 5 trials.'),
                              
                              HTML("Only the earliest evidence of results reporting from trial completion
                              was considered for both reporting of summary results in the registry and
@@ -247,32 +254,39 @@ methods_page <- tabPanel(
                              the OA status of publications in our sample.",
                              
                              HTML('This analysis was limited to trials with a journal publication and
-                             a DOI. We queried the Unpaywall database via its <a href="https://unpaywall.org/products/api">API</a>
-                        to obtain information on the OA status of publications. Publications can have different OA statuses which are
-                        color-coded. Gold OA denotes a publication in an OA journal. Green OA denotes a
-                        freely available repository version. Hybrid OA denotes an OA publication in a journal
-                        which offers both a subscription based model as well as an OA option. The category
-                        \"Bronze\" denotes a publication which is freely available on the journal page,
-                        but without a clear open license. These can be articles in a non-OA journal which
-                        have been made available voluntarily by the journal, but which might at some stage
-                        lose their OA status again. We only considered the following categories as OA in this
-                        dashboard: Gold OA, Green OA, and Hybrid OA. As a publication can have several OA
-                        versions (e.g., a gold version in an OA journal as well as a green version in a repository),
-                        we define a hierarchy for the OA categories and for each publication only assign the
-                        OA category with the highest priority. We use a hierarchy of gold - hybrid - green
-                        (journal version before repository version), as also implemented in the Unpaywall
-                        database itself.
+                             a DOI. We queried the Unpaywall database via its
+                             <a href="https://unpaywall.org/products/api">API</a> to obtain information
+                             on the OA status of publications. Publications can have different OA
+                             statuses which are color-coded. Gold OA denotes a publication in an
+                             OA journal. Green OA denotes a freely available repository version.
+                             Hybrid OA denotes an OA publication in a journal which offers
+                             both a subscription based model as well as an OA option. Bronze OA denotes
+                             publications which are freely available on the journal page, but
+                             without a clear open license. These can be articles in a non-OA journal
+                             which have been made available voluntarily by the journal,
+                             but which might at some stage lose their OA status again. Therefore, we
+                             only considered the OA categories Gold, Green, and Hybrid. As publications
+                             can have several OA versions (e.g., a gold version
+                             in an OA journal as well as a green version
+                             in a repository), we defined a hierarchy for categories and
+                             for each publication only assigned the category with the highest priority.
+                             We used a hierarchy of gold - hybrid - green. A more detailed breakdown
+                             of the absolute number of publications across all
+                             categories can be visualised by clicking on the toggle next to the plot.
+                             \"No data\" refers to publications which could not be resolved in Unpaywall.
                         <br>
-                        <br>OA status is not fixed but rather changes over time, as repository versions are often made available with a delay.
-                        Therefore, the OA percentage for a given year typically rises retrospectively. Thus, the point in time
+                        <br>OA status is not fixed but rather changes over time, as repository versions
+                        are often made available with a delay. Therefore, the OA percentage for a given
+                        year typically rises retrospectively. Thus, the point in time
                         at which the OA status is retrieved is important for the OA percentage. The current
                         OA data was retrieved with <a href="https://github.com/NicoRiedel/unpaywallR">
                              UnpaywallR</a> on: 15/07/2021.'),
                              
                              "Unpaywall only stores information for publications which have a DOI assigned by
-                        Crossref. Articles without a Crossref DOI were therefore excluded from the OA analysis."),
+                        Crossref. Articles without a Crossref DOI were therefore excluded from the OA analysis.
+                             The plot only shows data for publication years with more than 20 publications."),
                
-               methods_panel("Potential Green Open Access",
+               methods_panel("Realized potential for Green Open Access",
                              
                              HTML("In many cases, journal or publisher self-archiving policies allow researchers
                              to make the accepted or published version of their publication openly
@@ -292,18 +306,17 @@ methods_page <- tabPanel(
                              only accessible in a repository (Green OA only). To do so, we queried the
                              Unpaywall API (with <a href="https://github.com/NicoRiedel/unpaywallR">
                              UnpaywallR</a>) with the following hierarchy: gold - hybrid - bronze - green - 
-                             closed. These are previously paywalled publications which have been made
-                             available in a repository (either through self-archiving or via the journal).
-                             In a second step, we identified how many paywalled publications could technically
-                             be made openly accessible based on self-archiving permissions. To obtain this information,
-                             we queried the <a href="https://openaccessbutton.org/api">
-                             Shareyourpaper.org permissions API</a> (OA.Works) which combines publication
-                             metadata and policy information to provide permissions. Publications
-                             were considered to have the potential for green OA if: (1) a \"best permission\" was
-                             found; (2) this permission relates to either the accepted or published version of
-                             the publication; (3) this permission relates to archiving in an institutional repository;
-                             and (4) the embargo linked to this permission had elapsed (if applicable). we did
-                             not consider permissions relating to the submitted version. The Unpaywall database
+                             closed. In a second step, we identified how many paywalled publications
+                             could technically be made openly accessible based on self-archiving permissions.
+                             To obtain this information, we queried the
+                             <a href="https://openaccessbutton.org/api">Shareyourpaper.org permissions API</a>
+                             (OA.Works) which combines publication metadata and policy information to provide
+                             permissions. Publications were considered to have the potential for green OA
+                             if: (1) a \"best permission\" was found; (2) this permission relates to either
+                             the accepted or published version of the publication; (3) this permission
+                             relates to archiving in an institutional repository; and (4) the embargo
+                             linked to this permission had elapsed (if applicable). We did not consider
+                             permissions relating to the submitted version. The Unpaywall database
                              was queried on 15/07/2021. The Shareyourpaper permissions API was queried on
                              23/07/2021.'),
                              
@@ -334,41 +347,43 @@ methods_page <- tabPanel(
 
 ## Tooltips for Open Science metrics
 
-openaccess_tooltip <- strwrap("The Open Access (OA) metric shows the percentage of
-                              research publications that are OA. This analysis was
-                              limited to trials with a
-                              journal publication for which a DOI has been assigned.
-                              We only considered the following categories as OA
-                              in this dashboard: Gold OA, Green OA, and Hybrid OA.
-                              Gold OA denotes publication
-                              in a pure OA journal. Green OA denotes a freely
-                              available repository version. Hybrid OA denotes an
-                              OA publication in a journal which offers both a
-                              subscription based model as well as an OA option.
-                              The number of publications and their OA
-                              status can be visualised by clicking on the toggle
-                              next to the plot. Here, further categories are
-                              included: Bronze denotes a publication which is
-                              freely available on the journal page, but without a
-                              clear open license; Closed publications are not freely
-                              available; \"No data\" refers to publications which
-                              could not be resolvd in Unpaywall. As one publication
-                              can have several OA versions, we define a hierarchy
-                              and for each publication only assign the OA category
-                              with the highest priority. Here, we
-                              used a hierarchy of gold - hybrid - green. More
-                              information can be found in the Methods page.") %>%
+openaccess_tooltip <- strwrap("This metric shows the percentage of
+                              publications that are Open Access (OA). This analysis was
+                              limited to trials with a journal publication and a DOI.
+                              Publications can have different OA statuses which are color-coded.
+                              Gold OA denotes a publication in an OA journal. Green
+                              OA denotes a freely available repository version.
+                              Hybrid OA denotes an OA publication in a journal
+                              which offers both a subscription based model as well
+                              as an OA option. As publications can have several
+                              OA versions, we defined a hierarchy for categories
+                              and for each publication only assigned the category 
+                              with the highest priority. Here, we used a hierarchy
+                              of gold - hybrid - green. The absolute number of
+                              publications and their OA status can be visualised
+                              by clicking on the toggle next to the plot. Here,
+                              further categories not considered as Open Access
+                              in this dashboard are also included. More information
+                              can be found in the Methods page.") %>%
     paste(collapse = " ")
+
+lim_openaccess_tooltip <- strwrap("Unpaywall only stores information for publications
+                                  which have a DOI assigned by Crossref. Publications
+                                  without a Crossref DOI had to be excluded from
+                                  the OA analysis. The OA percentage is not a fixed
+                                  number, but changes over time as some publications
+                                  become accessible with a delay. The current data
+                                  was retrieved on: 15/07/2021.")
 
 greenopenaccess_tooltip <- strwrap('This metric measures how many paywalled publications
                             with the potential for green OA have been made available
                             via this route. This analysis was limited to trials
-                            with a journal publication for which a DOI has been assigned.
+                            with a journal publication and a DOI.
                             In a first step, we identified publications which are
-                             only accessible via Green OA (in a repository). To do
+                             only accessible in a repository (Green OA only). To do
                              so, we queried the Unpaywall API  with the following
                              hierarchy: gold - hybrid - bronze - green - 
-                             closed. We then identified how many paywalled publications
+                             closed. Next, we identified how many paywalled publications
                              could technically be made openly accessible based on
                              self-archiving permissions. We obtained this information
                              by querying the Shareyourpaper.org permissions API (OA.Works).
@@ -377,10 +392,21 @@ greenopenaccess_tooltip <- strwrap('This metric measures how many paywalled publ
                              archiving the accepted or published version in an
                              institutional repository, and if the embargo had elapsed
                              (if applicable). Click on the toggle on the left to
-                             view the number of paywalled publications and their
+                             view the absolute number of paywalled publications and their
                              potential for self-archiving. More information can be
                              found in the Methods page.') %>%
     paste(collapse = " ")
+
+lim_greenopenaccess_tooltip <- strwrap("Not all publications queried were resolved
+                                in Unpaywall and ShareYourPaper. We also only extracted
+                                permissions data for publications which have a
+                                \"best permission\" in the Shareyourpaper.org database.
+                                The date at which a publication can be made openly
+                                accessible via self-archiving depends on the publication
+                                date and the length of the embargo (if any). Therefore,
+                                the number of paywalled publications with the potential
+                                for green OA will change over time. The Shareyourpaper
+                                permissions API was queried on 23/07/2021.")
 
 opendata_tooltip <- strwrap("This metric measures the percentage of screened publications that state
                                 that they shared their research data. We used the text-mining algorithm
@@ -391,6 +417,8 @@ opendata_tooltip <- strwrap("This metric measures the percentage of screened pub
 
 paste(collapse = " ")
 
+lim_opendata_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all Open Data publications and finds false positive cases (no manual check of the results). ODDPub also does not verify that the dataset is available and whether it fulfills our definition of Open Data. Finally, Open Data is not relevant for all publications.")
+
 opencode_tooltip <- strwrap("The Open Code metric measures the percentage of screened publications
                              that state that they shared their analysis code. We used the text-mining
                              algorithm ODDPub to identify publications which share analysis code.
@@ -399,69 +427,146 @@ opencode_tooltip <- strwrap("The Open Code metric measures the percentage of scr
 
 paste(collapse = " ")
 
+lim_opencode_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all publications with Open Code and finds false positive cases (no manual check of the results). ODDPub also does not verify that the code is available and whether it fulfills our definition of Open Code Finally, Open Code is not relevant for all publications.")
+
 ## Tooltips for Clinical Trials metrics
 
-trn_tooltip <- strwrap("This metric measures how many clinical trials report a trial registration number (TRN) in the abstract and in the
-                        full-text of the publication. Reporting of clinical trial registration
-                        numbers in related publications facilitates transparent linkage between registration and
-                        publication. The CONSORT as well as the ICMJE Recommendations for the Conduct, Reporting,
-                        Editing, and Publication of Scholarly Work in Medical Journals call for reporting
-                        <i>&#39trial registration number and name of the trial register&#39</i> in both the
-                       full-text and abstract.") %>%
+trn_tooltip <- strwrap("This metric measures how many clinical trials with a journal publication
+                        report a trial registration number (TRN) in the abstract and in the
+                        full text of the publication. Reporting of TRNs in related publications
+                        facilitates transparent linkage between registration and publication.
+                        We developed open source R sripts to detect TRNs using a regular-expression-based
+                        approach. This analysis was limited to trials registered in
+                        ClinicalTrials.gov and/or DRKS for which a journal publication was found.
+                        The analysis was further restricted to publications indexed in PubMed
+                        (detection of TRN in abstract) and publications for which we could obtain
+                        the full text (detection of TRN in full text). More information can be
+                        found in the Methods page.") %>%
 
 paste(collapse = " ")
 
+lim_trn_tooltip <- strwrap(HTML("The regular expressions detect any and all TRNs in an abstract and publication and do not distinguish
+                             between cases where a TRN is reported as a registration for the publication&#39s
+                             study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review, reference to other clinical trials, etc.).
+                             Finally, this analysis was limited to journal publications indexed in PubMed (TRN in abstract)
+                             and for which we could obtain the full text (TRN in full text)."))
 
-linkage_tooltip <- strwrap("This metric measures how many clinical trial registry entries provide links to the journal publication of the primary outcome for the trial in question.")
+linkage_tooltip <- strwrap("This metric measures links to the published journal article in clinical trial
+                             registry entries. Linking to the publication in the registration make results
+                             publication more findable and aids in evidence synthesis. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS for which a
+                             journal publication was found. The analysis was further restricted to publications
+                             with a DOI or that are indexed in PubMed. We queried the ClinicalTrials.gov and
+                             DRKS APIs to obtain linked publications in these registries. We considered a
+                             publication “linked” if the PMID or DOI was included in the trial registration.
+                             More information can be found in the Methods page.")
 
-lim_linkage_tooltip <- strwrap("This metric only captures clinical trial registry entries that link to the final, full-text publication of the primary outcome for the trial in question.")
+lim_linkage_tooltip <- strwrap("ClinicalTrials.gov includes a often-used
+                             PMID field for references. In addition, ClinicalTrials.gov automatically
+                             indexes publications from PubMed using TRN in the secondary identifier field.
+                             In contrast, DRKS includes references as a free-text field, leaving trialists
+                             to decide whether to enter any publication identifiers. Finally, this analysis
+                             was limited to trials with a journal publication which have a DOI or are
+                             indexed in PubMed.")
 
-allumc_linkage_tooltip <- strwrap("This metric measures how many clinical trial registry entries provide links to the journal publication of the primary outcome for the trial in question.")
-
-lim_allumc_linkage_tooltip <- strwrap("This metric only captures clinical trial registry entries that link to the final, full-text publication of the primary outcome for the trial in question.")
-
-sumres_tooltip <- strwrap("This metric measures how many clinical trials registered in the
-                        EU Clinical Trials Register that are due to report their results have already
-                        done so. A trial is due to report its results 12 month after trial completion.
-                        The data were retrieved from the EU Trials Tracker by the EBM DataLab
-                        (eu.trialstracker.net). Clinical trials are expensive and have often many contributing
-                        patients. A timely dissemination of the trial results is crucial to make the evidence
-                        gained in those trials available. The World Health organization recommends publishing
-                        clinical trial results within one year after the end of a study.") %>%
+sumres_tooltip <- strwrap("This metric measures how many clinical trials registered in EudraCT and
+                             that are due to report results in the EU Clinical Trials Register (EUCTR) have
+                             already done so. Interventional clinical trials using investigational medicinal
+                             products conducted in the EU/EEA are required to be registered in EudraCT.
+                             Sponsors of these trials are required to provide summary results within 12
+                             months of trial completion. Summary results reporting rates in EUCTR were
+                             retrieved from the EU Trials Tracker. Thus, the analysis was limited
+                             to trials listed in the EU Trials Tracker with a sponsor name corresponding
+                             to one of the UMCs presented here. Note that some trials
+                             registered in EudraCT and captured in this analysis may be cross-registered
+                             in ClinicalTrials.gov and/or DRKS. However, this plot displays summary results
+                             reporting only in EUCTR as listed in the EU Trials Tracker. More information
+                             can be found in the Methods page.") %>%
     
 paste(collapse = " ")
 
-prereg_tooltip <- strwrap("This metric measures if the clinical trials are registered before the
-                        start date of the study, according to the information given on ClinicalTrials.gov or DRKS.de.
-                        The idea of prospective registration of studies is to make the trial specifications,
-                        including primary and secondary outcomes, publicly available before study start.
-                        Prospective registration adds transparency, helps protect against outcome switching.") %>%
+lim_sumres_tooltip <- strwrap("The EU Trials Tracker does not measure for how long trials have been due to
+                             report results. For UMCs with more than one corresponding sponsor name in the
+                             EU Trials Tracker, some trials may have been missed since we only selected
+                             maximum one sponsor name per UMC.")
+
+prereg_tooltip <- strwrap("This metric reflects whether a clinical trial was registered before the
+                        start date of the study. Prospective registration makes trial specifications,
+                        including primary and secondary outcomes, publicly available before study start,
+                        adds transparency and accountability, and helps protect against outcome switching.
+                        This analysis was limited to trials registered in
+                        ClinicalTrials.gov and/or DRKS with a start date given in the registry. To
+                        assess whether a study was prospectively registered, we compared the date
+                        the study was first submitted to the registry with the start date given in
+                        the registry. We defined a trial to be prospectively registered if the trial
+                        was registered in the same or a previous month to the trial start date, as
+                          some registrations provide only a start month rather than an exact date.
+                          More information can be found in the Methods page.") %>%
     
 paste(collapse = " ")
 
-timpub_tooltip2 <- strwrap("This metric measures how many clinical trials registered on ClinicalTrials.gov or DRKS.de
-                        reported their results either as a journal publication or as summary results on the
-                        trials registry within 2 years after completion. Trials completed between 2009
-                        and 2017 were considered. The results were previously published as part of the
-                        IntoValue study (https://s-quest.bihealth.org/intovalue/). Clinical trials are expensive
-                        and often have many contributing patients. A fast dissemination of the trial results
-                        is crucial to make the evidence gained in those trials available. The World Health
-                        organization recommends publishing clinical trial results within one year after the
-                        end of a study.") %>%
+lim_prereg_tooltip <- strwrap("Trial registration was assessed for clinical trials registered in
+                             ClinicalTrials.gov and/or DRKS. We did not evaluate trials in further
+                             registries. The data presented relies on the information in registry
+                             entries being accurate and complete. Finally, trials without
+                             a start date in the registry were excluded from this analysis.")
 
-    paste(collapse = " ")
-
-timpub_tooltip5 <- strwrap("This metric measures how many clinical trials registered on ClinicalTrials.gov or DRKS.de
-                        reported their results either as a journal publication or as summary results on the
-                        trials registry within 5 years after completion. Trials completed between 2009
-                        and 2017 were considered. The results were previously published as part of the
-                        IntoValue study (https://s-quest.bihealth.org/intovalue/). Clinical trials are expensive
-                        and often have many contributing patients. A fast dissemination of the trial results
-                        is crucial to make the evidence gained in those trials available. The World Health
-                        organization recommends publishing clinical trial results within one year after the
-                        end of a study.") %>%
+timpub_tooltip2 <- strwrap("This metric measures how many clinical trials in our dataset that
+                             reported results within 2 years of trial completion as (a) a
+                             journal publication and  (b) summary results in the registry.
+                             A fast dissemination of trial results is crucial to make the
+                             evidence gained in those trials available. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS.
+                             Both registries were searched for studies with one of the UMCs as
+                             the responsible party/sponsor or with a principal investigator from one of
+                             the UMCs. A manual search for published results was done, searching the
+                             registry, PubMed, and Google. If multiple results publications were found,
+                             only the earliest was included. Publication dates were manually entered during
+                             publication searches. When calculating the 2-year reporting
+                             rates, we only considered trials for which we had 2 years follow-up
+                             time since trial completion. More information can be found in the
+                              Methods page.") %>%
 
 paste(collapse = " ")
+
+lim_timpub_tooltip2 <- strwrap("Only the earliest evidence of results reporting from trial completion
+                             was considered for both reporting of summary results in the registry and
+                             as a journal publication. Thus, the data presented
+                             does not reflect all result publications of a given trial. Moreover, some of
+                             the publications may have been missed in the manual search procedure as the
+                             search was restricted to a limited number of scientific databases and the 
+                             responsible parties were not contacted. Observational clinical studies were
+                             not included in this sample. The data presented relies on the information
+                             in registry entries being accurate and complete.")
+
+timpub_tooltip5 <- strwrap("This metric measures how many clinical trials in our dataset that
+                             reported results within 5 years of trial completion as (a) a
+                             journal publication and  (b) summary results in the registry.
+                             A fast dissemination of trial results is crucial to make the
+                             evidence gained in those trials available. This analysis was
+                             limited to trials registered in ClinicalTrials.gov and/or DRKS.
+                             Both registries were searched for studies with one of the UMCs as
+                             the responsible party/sponsor or with a principal investigator from one of
+                             the UMCs. A manual search for published results was done, searching the
+                             registry, PubMed, and Google. If multiple results publications were found,
+                             only the earliest was included. Publication dates were manually entered during
+                             publication searches. When calculating the 5-year reporting
+                             rates, we only considered trials for which we had 5 years follow-up
+                             time since trial completion. The plot only displays data for
+                             completion years with more than 5 trials. More information can be found in the
+                              Methods page.") %>%
+
+paste(collapse = " ")
+
+lim_timpub_tooltip5 <- strwrap("Only the earliest evidence of results reporting from trial completion
+                             was considered for both reporting of summary results in the registry and
+                             as a journal publication. Thus, the data presented
+                             does not reflect all result publications of a given trial. Moreover, some of
+                             the publications may have been missed in the manual search procedure as the
+                             search was restricted to a limited number of scientific databases and the 
+                             responsible parties were not contacted. Observational clinical studies were
+                             not included in this sample. The data presented relies on the information
+                             in registry entries being accurate and complete.")
 
 ## Tooltips for Robustness metrics
 
@@ -506,61 +611,3 @@ paste(collapse = " ")
 lim_randomization_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, randomization may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
 lim_blinding_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, blinding may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
 lim_power_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, sample size calculation may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
-lim_sumres_tooltip <- strwrap("While the EU Clinical Trials Register is one of the most important European trial registries, it is not the only available registry. There are other registries such as ClinicalTrials.gov. or the German Clinical Trials Registry, which are not considered here. Additionally, the EU Trials Tracker does not measure for how long the trials have been due. Finally, we only considered the latest data available in the EU Trials Tracker. We plan to include historic data in the future.")
-lim_prereg_tooltip <- strwrap("We focused on ClinicalTrials.gov and DRKS.de while there are other available registries as well. Also, we rely on the information on ClinicalTrials.gov and DRKS.de being accurate.")
-lim_timpub_tooltip2 <- strwrap("Some detected publications might be missed in the manual search procedure as we only searched a limited number of scientific databases and did not contact the responsible parties. Furthermore, we did not include observational clinical studies in our sample. Additionally, we might overestimate the time to publication for some studies as we stopped the manual search after the first detected publication.")
-lim_timpub_tooltip5 <- strwrap("Some detected publications might be missed in the manual search procedure as we only searched a limited number of scientific databases and did not contact the responsible parties. Furthermore, we did not include observational clinical studies in our sample. Additionally, we might overestimate the time to publication for some studies as we stopped the manual search after the first detected publication.")
-lim_trn_tooltip <- strwrap(HTML("We identified human clinical trials based on the following search term in PubMed: &#39clinical trial&#39[pt] NOT (animals [mh] NOT humans [mh]). However, we have not tested (1) the sensitivity of this PubMed search term; (2) the precision of this search term. Our algorithm does not distinguish true TRNs that do not resolve to a registration. Our algorithm does not determine whether the TRN is reported as a registration for the publication&#39s study."))
-
-lim_openaccess_tooltip <- strwrap("Unpaywall only stores information for publications
-                                  which have a DOI assigned by Crossref. Publications
-                                  without a Crossref DOI had to be excluded from
-                                  the OA analysis. The OA percentage is not a fixed
-                                  number, but changes over time as some publications
-                                  become accessible with a delay. The current data
-                                  was retrieved on: 15/07/2021.")
-
-lim_greenopenaccess_tooltip <- strwrap("Not all publications queried were resolved
-                                in Unpaywall and ShareYourPaper. We also only extracted
-                                permissions data for publications which have a
-                                \"best permission\" in the Shareyourpaper.org database.
-                                The date at which a publication can be made openly
-                                accessible via self-archiving depends on the publication
-                                date and the length of the embargo (if any). Therefore,
-                                the number of paywalled publications with the potential
-                                for green OA will change over time. The Shareyourpaper
-                                permissions API was queried on 23/07/2021.")
-
-lim_opendata_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all Open Data publications and finds false positive cases (no manual check of the results). ODDPub also does not verify that the dataset is available and whether it fulfills our definition of Open Data. Finally, Open Data is not relevant for all publications.")
-lim_opencode_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all publications with Open Code and finds false positive cases (no manual check of the results). ODDPub also does not verify that the code is available and whether it fulfills our definition of Open Code Finally, Open Code is not relevant for all publications.")
-
-lim_allumc_openaccess_tooltip <- strwrap("Unpaywall only stores information for publications
-                                  which have a DOI assigned by Crossref. Publications
-                                  without a Crossref DOI had to be excluded from
-                                  the OA analysis. The OA percentage is not a fixed
-                                  number, but changes over time as some publications
-                                  become accessible with a delay. The current data
-                                  was retrieved on: 15/07/2021.")
-
-lim_allumc_opendata_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all Open Data publications and finds false positive cases (no manual check of the results). ODDPub also does not verify that the dataset is available and whether it fulfills our definition of Open Data. Finally, Open Data is not relevant for all publications.")
-lim_allumc_opencode_tooltip <- strwrap("This analysis could only be performed on articles for which we could access the full text. ODDPub only finds ~75% of all publications with Open Code and finds false positive cases (no manual check of the results). ODDPub also does not verify that the code is available and whether it fulfills our definition of Open Code Finally, Open Code is not relevant for all publications.")
-
-lim_allumc_clinicaltrials_trn_tooltip <- strwrap("We identified human clinical trials based on the following search term in PubMed: 'clinical trial'[pt] NOT (animals [mh] NOT humans [mh]). However, we have not tested (1) the sensitivity of this PubMed search term (i.e., what proportion of true clinical trial publications are detected?); (2) the precision of this search term (i.e, what proportion of detected publications are not true clinical trials publications?). Furthermore, our algorithm does not distinguish true TRNs that do not resolve to a registration. Finally, the algorithm does not determine whether the TRN is reported as a registration for the publication's study (i.e., clinical trial result) or is otherwise mentioned (i.e., in a review, reference to other clinical trials, etc.)")
-lim_allumc_clinicaltrials_sumres_tooltip <- strwrap("While the EU Clinical Trials Register is one of the most important European trial registries, it is not the only available registry. There are other registries such as ClinicalTrials.gov. or the German Clinical Trials Registry, which are not considered here. Additionally, the EU Trials Tracker does not measure for how long the trials have been due. Finally, we only considered the latest data available in the EU Trials Tracker. We plan to include historic data in the future.")
-lim_allumc_clinicaltrials_prereg_tooltip <- strwrap("Like in the case of the summary results metric, we only focused on the ClinicalTrials.gov while there are other available registries as well. Also, we rely on the information on ClinicalTrials.gov being accurate.")
-lim_allumc_clinicaltrials_timpub_tooltip <- strwrap("Some detected publications might be missed in the manual search procedure as we only searched a limited number of scientific databases and did not contact the responsible parties. Furthermore, we did not include observational clinical studies in our sample. Additionally, we might overestimate the time to publication for some studies as we stopped the manual search after the first detected publication.")
-lim_allumc_clinicaltrials_timpub_tooltip5a <- strwrap("Some detected publications might be missed in the manual search procedure as we only searched a limited number of scientific databases and did not contact the responsible parties. Furthermore, we did not include observational clinical studies in our sample. Additionally, we might overestimate the time to publication for some studies as we stopped the manual search after the first detected publication.")
-lim_allumc_animal_rando_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, randomization may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
-lim_allumc_animal_blind_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, blinding may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
-lim_allumc_animal_power_tooltip <- strwrap("We did not test the sensitivity and precision of the approach used to identify animal studies in our dataset, nor the data obtained from SciScore. Moreover, we do not have SciScore data for all studies in our publication set. Finally, sample size calculation may not always apply, especially in early-stage exploratory research (hypothesis-generating experiments).")
-
-lim_allumc_greenoa_tooltip <- strwrap("Not all publications queried were resolved
-                                in Unpaywall and ShareYourPaper. We also only extracted
-                                permissions data for publications which have a
-                                \"best permission\" in the Shareyourpaper.org database.
-                                The date at which a publication can be made openly
-                                accessible via self-archiving depends on the publication
-                                date and the length of the embargo (if any). Therefore,
-                                the number of paywalled publications with the potential
-                                for green OA will change over time. The Shareyourpaper
-                                permissions API was queried on 23/07/2021.")

--- a/methods_page.R
+++ b/methods_page.R
@@ -215,7 +215,7 @@ methods_page <- tabPanel(
                              registry, PubMed, and Google. If multiple results publications were found,
                              the earliest was included. When calculating the 2-year and 5-year reporting
                              rates, we only considered trials for which we had 2 and 5 years follow-up
-                             time since trial completion, respectively.'),
+                             time since trial completion, respectively. Publication dates were manually entered during publication searches.'),
                              
                              HTML("Only the earliest evidence of results reporting from trial completion
                              was considered for both reporting of summary results in the registry and

--- a/prep/prep-intovalue.R
+++ b/prep/prep-intovalue.R
@@ -4,7 +4,7 @@ library(here)
 library(fs)
 
 ## Get intovalue.rds from https://github.com/maia-sh/intovalue-data/
-intovalue <- rio::import("https://github.com/maia-sh/intovalue-data/blob/main/data/processed/intovalue.rds?raw=true")
+intovalue <- rio::import("https://github.com/maia-sh/intovalue-data/blob/main/data/processed/trials.rds?raw=true")
 
 ## Apply the IntoValue exclusion criteria
 intovalue <- intovalue %>%
@@ -16,6 +16,10 @@ intovalue <- intovalue %>%
         ## In case of dupes, exclude IV1 version
         !(is_dupe & iv_version == 1)
     )
+
+# Trials with a journal article have a publication (disregard dissertations and abstracts) %>% 
+intovalue <- intovalue %>%
+    mutate(has_publication = if_else(publication_type == "journal publication", TRUE, FALSE, missing = FALSE))
 
 iv_all <- intovalue
 

--- a/start_page_plots.R
+++ b/start_page_plots.R
@@ -91,13 +91,13 @@ plot_clinicaltrials_trn <- function (dataset, color_palette) {
         nrow()
     
     all_numer_ft <- dataset %>%
-        filter(has_iv_trn_ft_pdf == TRUE) %>%
+        filter(has_iv_trn_ft == TRUE) %>%
         nrow()
     ft_denom <- dataset %>%
         filter(
             has_publication == TRUE,
             publication_type == "journal publication",
-            has_ft_pdf == TRUE
+            has_ft == TRUE
         ) %>%
         nrow()
     

--- a/umc_page.R
+++ b/umc_page.R
@@ -20,10 +20,12 @@ umc_page <- tabPanel(
                     style = "margin-left: 0",
                     "This dashboard provides an overview of the performance of UMCs
                     in Germany on a set of practices relating to clinical research
-                    transparency. Select the UMC of interest from the drop-down
-                    menu below. More detailed information on the underlying
-                    methods can be found by clicking on the methods and limitations
-                    widgets next to each plot, or by consulting the Methods page."
+                    transparency. On this page, you can view the data for a UMC
+                    of interest contextualized to the average UMC data. Select
+                    the UMC of interest from the drop-down menu below. More
+                    detailed information on the underlying methods can be found
+                    in the methods and limitations widgets next to each plot, and
+                    in the Methods page."
                 ),
                 h4(style = "margin-left:0cm",
                    "The dashboard was developed as part of a scientific research

--- a/umc_plots.R
+++ b/umc_plots.R
@@ -126,14 +126,14 @@ umc_plot_clinicaltrials_trn <- function (dataset, dataset_all, umc, color_palett
         filter(
             has_publication == TRUE,
             publication_type == "journal publication",
-            has_ft_pdf == TRUE
+            has_ft == TRUE
         )
     
     plot_data_ft_all <- dataset_all %>%
         filter(
             has_publication == TRUE,
             publication_type == "journal publication",
-            has_ft_pdf == TRUE
+            has_ft == TRUE
         )
     
     all_numer_abs <- sum(plot_data_abs_all$has_iv_trn_abstract, na.rm=TRUE)
@@ -141,9 +141,9 @@ umc_plot_clinicaltrials_trn <- function (dataset, dataset_all, umc, color_palett
         filter(! is.na(has_iv_trn_abstract)) %>%
         nrow()
     
-    all_numer_ft <- sum(plot_data_ft_all$has_iv_trn_ft_pdf, na.rm=TRUE)
+    all_numer_ft <- sum(plot_data_ft_all$has_iv_trn_ft, na.rm=TRUE)
     ft_denom <- plot_data_ft_all %>%
-        filter(! is.na(has_iv_trn_ft_pdf)) %>%
+        filter(! is.na(has_iv_trn_ft)) %>%
         nrow()
 
     umc_abs_denom <- plot_data_abs %>%
@@ -159,13 +159,13 @@ umc_plot_clinicaltrials_trn <- function (dataset, dataset_all, umc, color_palett
 
     umc_numer_ft <- plot_data_ft %>%
         filter(city == umc) %>%
-        select(has_iv_trn_ft_pdf) %>%
-        filter(has_iv_trn_ft_pdf == TRUE) %>%
+        select(has_iv_trn_ft) %>%
+        filter(has_iv_trn_ft == TRUE) %>%
         nrow()
 
     umc_ft_denom <- plot_data_ft %>%
         filter(city == umc) %>%
-        filter(! is.na(has_iv_trn_ft_pdf)) %>%
+        filter(! is.na(has_iv_trn_ft)) %>%
         nrow()
 
     plot_data <- tribble(


### PR DESCRIPTION
- Updated text of the methods page, methods tooltips, and limitation tooltips across all pages (comments from team are integrated)
- Fix small bug with selection of tooltips
- Made updates to work with changes to the IV dataset (https://github.com/maia-sh/intovalue-data)
  - Update prep-intovalue script:
    - Read in `trials.rds` (filename change) 
    - Re-create `has_publication` variable as no longer exists in the IV dataset (TODO: short term fix based on us only considering journal publications for publication-based metrics, to be adapted)
  - Change `has_ft_pdf` to `has_ft` across all relevant scripts
  - Change `has_iv_trn_ft_pdf` to `has_iv_trn_ft` across all relevant scripts