### PR TITLE
Updates to OA plots

### DIFF
--- a/app.R
+++ b/app.R
@@ -1284,6 +1284,7 @@ server <- function (input, output, session) {
 
             ## Date range for OA
             min_oa <- oa_set %>%
+                filter(city == input$selectUMC) %>%
                 select(publication_date) %>%
                 arrange(publication_date) %>%
                 slice_head() %>%
@@ -1291,6 +1292,7 @@ server <- function (input, output, session) {
                 format("%Y")
 
             max_oa <- oa_set %>%
+                filter(city == input$selectUMC) %>%
                 select(publication_date) %>%
                 arrange(publication_date) %>%
                 slice_tail() %>%
@@ -1321,6 +1323,7 @@ server <- function (input, output, session) {
 
             ## Date range for Green OA
             min_oa_green <- oa_set_green %>%
+                filter(city == input$selectUMC) %>%
                 select(publication_date) %>%
                 arrange(publication_date) %>%
                 slice_head() %>%
@@ -1328,6 +1331,7 @@ server <- function (input, output, session) {
                 format("%Y")
 
             max_oa_green <- oa_set_green %>%
+                filter(city == input$selectUMC) %>%
                 select(publication_date) %>%
                 arrange(publication_date) %>%
                 slice_tail() %>%

--- a/methods_page.R
+++ b/methods_page.R
@@ -419,14 +419,14 @@ lim_openaccess_tooltip <- strwrap("Unpaywall only stores information for publica
 greenopenaccess_tooltip <- strwrap('This metric measures how many paywalled publications
                             with the potential to be archived in a repository have
                             been made openly accessible via this route (green OA).
-                            Clicking on the toggle shows that many paywalled 
-                            publications have a self-archiving permission and could
-                            therefore be made openly accessible via this route.
-                            This analysis
-                            was limited to trials with a journal publication and
-                            a DOI that were resolved in Unpaywall. In a first step,
-                            we queried the Unpaywall API to identify publications
-                            that are only accessible in a repository (Green OA only).
+                            Clicking on the toggle shows that many publications
+                            behind a paywall have a permission for self-archiving
+                            and could therefore be made openly accessible via this route
+                            (light green). This analysis was limited to trials with
+                            a journal publication and a DOI that were resolved in
+                            Unpaywall. In a first step, we queried the Unpaywall
+                            API to identify publications that are only accessible
+                            in a repository (Green OA only).
                             Next, we identified how many paywalled publications
                             could technically be made openly accessible based on
                             self-archiving permissions. We obtained this information

--- a/start_page_plots.R
+++ b/start_page_plots.R
@@ -893,7 +893,7 @@ plot_opensci_green_oa <- function (dataset, absnum, color_palette) {
             
             all_no_data <- oa_set_abs %>%
                 filter(
-                    color == "bronze" | color == "closed",
+                    color == "closed",
                     is.na(is_closed_archivable),
                     oa_year == year
                 ) %>%

--- a/umc_plots.R
+++ b/umc_plots.R
@@ -1221,7 +1221,7 @@ umc_plot_opensci_green_oa <- function (dataset, dataset_all, umc, absnum, color_
             umc_no_data <- oa_set_abs %>%
                 filter(
                     city == umc,
-                    color == "bronze" | color == "closed",
+                    color == "closed",
                     is.na(is_closed_archivable),
                     oa_year == year
                 ) %>%

--- a/umc_plots.R
+++ b/umc_plots.R
@@ -1145,6 +1145,19 @@ umc_plot_opensci_green_oa <- function (dataset, dataset_all, umc, absnum, color_
             ! is.na(publication_date_unpaywall)
         )
     
+    umc_denom <- oa_set %>%
+        filter(
+            city == umc
+        ) %>%
+        nrow()
+    
+    umc_numer <- oa_set %>%
+        filter(
+            city == umc,
+            color_green_only == "green"
+        ) %>%
+        nrow()
+    
     all_denom <- oa_set_all %>%
         nrow()
     
@@ -1163,21 +1176,7 @@ umc_plot_opensci_green_oa <- function (dataset, dataset_all, umc, absnum, color_
             ! is.na(publication_date_unpaywall)
         )
     
-    #Again use the denominator for the percentage plot
-    umc_denom <- oa_set %>%
-        filter(
-            city == umc
-        ) %>%
-        nrow()
-    
-    umc_numer <- oa_set %>%
-        filter(
-            city == umc,
-            color_green_only == "green"
-        ) %>%
-        nrow()
-    
-    #Again use the denominator for the absolute number plot
+    #Denominator for the absolute number plot
     
     if (absnum) {
 


### PR DESCRIPTION
- Green OA absolute number plot (Start page and One UMC page): focus on paywalled publications only (instead of paywalled and bronze publications)
  - [ ] TODO: Note that the dataset in the intovalue-data repository has been changed! Both `ct-dashboard-intovalue-all.csv` and `ct-dashboard-intovalue-umc.csv` datasets need to be updated in the server (https://github.com/quest-bih/clinical-dashboard/issues/35)
- One UMC page: customised date ranges of pink descriptor text of OA and green OA plots
- Clarified green OA tooltip text
- Changed order of green OA code (One UMC) for clarity