### PR TITLE
Split city instead of lead_cities for iv_umc dataset

### DIFF
--- a/prep/prep-intovalue.R
+++ b/prep/prep-intovalue.R
@@ -19,15 +19,14 @@ intovalue <- intovalue %>%
 
 # Trials with a journal article have a publication (disregard dissertations and abstracts) %>%
 intovalue <- intovalue %>%
-    mutate(has_publication = if_else(publication_type == "journal publication", TRUE, FALSE, missing = FALSE)) %>%
-    mutate(city = lead_cities)
+    mutate(has_publication = if_else(publication_type == "journal publication", TRUE, FALSE, missing = FALSE))
 
 iv_all <- intovalue
 
 ## Un-nest the cities
 iv_umc <- intovalue %>%
-    mutate(lead_cities = strsplit(as.character(lead_cities), " ")) %>%
-    tidyr::unnest(lead_cities)
+    mutate(city = strsplit(as.character(lead_cities), " ")) %>%
+    tidyr::unnest(city)
 
 ## This creates a data folder, if it doesn't exist already
 dir_create("data")


### PR DESCRIPTION
- Split on `city` instead of `lead_cities` for the iv_umc dataset as filtering on `city` in the dashboard
- Note that the iv_all dataset only contains `lead_cities`