### PR TITLE
Align with new intovalue reporting follow-up variables and update content

### DIFF
--- a/all_umc_plots.R
+++ b/all_umc_plots.R
@@ -371,9 +371,6 @@ plot_allumc_clinicaltrials_sumres <- function (dataset, iv_dataset, toggled_regi
 ## Timely reporting (2 years)
 plot_allumc_clinicaltrials_timpub <- function (dataset, rt, color_palette, color_palette_bars) {
     
-    dataset <- dataset %>%
-        filter(has_followup_2y == TRUE)
-
     plot_data <- tribble (
         ~x_label, ~percentage, ~mouseover
     )
@@ -383,8 +380,14 @@ plot_allumc_clinicaltrials_timpub <- function (dataset, rt, color_palette, color
         umc_numer <- dataset %>%
             filter(
                 city == umc,
-                is_summary_results_2y | is_publication_2y
+                (has_followup_2y_sumres & is_summary_results_2y) | (has_followup_2y_pub & is_publication_2y)
             ) %>%
+            nrow()
+        
+        umc_denom <- dataset %>%
+            filter(
+                has_followup_2y_pub | has_followup_2y_sumres,
+                city == umc) %>%
             nrow()
 
         if (rt == "Summary results only") {
@@ -392,10 +395,17 @@ plot_allumc_clinicaltrials_timpub <- function (dataset, rt, color_palette, color
             umc_numer <- dataset %>%
                 filter(
                     city == umc,
+                    has_followup_2y_sumres,
                     is_summary_results_2y
                 ) %>%
                 nrow()
             
+            umc_denom <- dataset %>%
+                filter(
+                    city == umc,
+                    has_followup_2y_sumres
+                ) %>%
+                nrow()
         }
 
         if (rt == "Publication only") {
@@ -403,15 +413,18 @@ plot_allumc_clinicaltrials_timpub <- function (dataset, rt, color_palette, color
             umc_numer <- dataset %>%
                 filter(
                     city == umc,
+                    has_followup_2y_pub,
                     is_publication_2y
                 ) %>%
                 nrow()
             
+            umc_denom <- dataset %>%
+                filter(
+                    city == umc,
+                    has_followup_2y_pub
+                ) %>%
+                nrow()
         }
-
-        umc_denom <- dataset %>%
-            filter(city == umc) %>%
-            nrow()
 
         plot_data <- plot_data %>%
             bind_rows(
@@ -459,9 +472,6 @@ plot_allumc_clinicaltrials_timpub <- function (dataset, rt, color_palette, color
 
 plot_allumc_timpub_5a <- function (dataset, rt, color_palette, color_palette_bars) {
 
-    dataset <- dataset %>%
-        filter(has_followup_5y == TRUE)
-
     plot_data <- tribble (
         ~x_label, ~percentage, ~mouseover
     )
@@ -471,8 +481,14 @@ plot_allumc_timpub_5a <- function (dataset, rt, color_palette, color_palette_bar
         umc_numer <- dataset %>%
             filter(
                 city == umc,
-                is_summary_results_5y | is_publication_5y
+                (has_followup_5y_sumres & is_summary_results_5y) | (has_followup_5y_pub & is_publication_5y)
             ) %>%
+            nrow()
+        
+        umc_denom <- dataset %>%
+            filter(
+                city == umc,
+                has_followup_5y_sumres | has_followup_5y_pub) %>%
             nrow()
 
         if (rt == "Summary results only") {
@@ -480,10 +496,17 @@ plot_allumc_timpub_5a <- function (dataset, rt, color_palette, color_palette_bar
             umc_numer <- dataset %>%
                 filter(
                     city == umc,
+                    has_followup_5y_sumres,
                     is_summary_results_5y
                 ) %>%
                 nrow()
             
+            umc_denom <- dataset %>%
+                filter(
+                    city == umc,
+                    has_followup_5y_sumres
+                ) %>%
+                nrow()
         }
 
         if (rt == "Publication only") {
@@ -491,15 +514,18 @@ plot_allumc_timpub_5a <- function (dataset, rt, color_palette, color_palette_bar
             umc_numer <- dataset %>%
                 filter(
                     city == umc,
+                    has_followup_5y_pub,
                     is_publication_5y
                 ) %>%
                 nrow()
             
+            umc_denom <- dataset %>%
+                filter(
+                    city == umc,
+                    has_followup_5y_pub
+                ) %>%
+                nrow()
         }
-
-        umc_denom <- dataset %>%
-            filter(city == umc) %>%
-            nrow()
 
         plot_data <- plot_data %>%
             bind_rows(

--- a/all_umcs_page.R
+++ b/all_umcs_page.R
@@ -23,13 +23,10 @@ lim_allumc_openaccess_tooltip <- strwrap("The OA status could only be obtained f
                                 perform a manual check of the OA data.")
 
 allumc_greenoa_tooltip <- strwrap("This metric shows the percentage of paywalled trial publications
-                            that have been made openly accessible in a repository (green OA). Click
-                            on the toggle to view absolute numbers (light green shows the number of
-                            publications currently behind a paywall that could be made openly
-                            accessible in a repository based on self-archiving permissions). This analysis was
-                              limited to trials registered in ClinicalTrials.gov
+                            that have been made openly accessible in a repository (green OA). This
+                            analysis was limited to trials registered in ClinicalTrials.gov
                               or DRKS with a journal publication and a DOI that
-                              resolved in Unpaywall. In a first step, we queried the Unpaywall API to identify
+                              resolved in Unpaywall. In the first step, we queried the Unpaywall API to identify
                             publications that are only accessible in a repository (Green OA only).
                             Next, we queried Shareyourpaper.org (OA.Works) via its API to obtain
                             self-archiving permissions of paywalled publications. The date at
@@ -87,7 +84,8 @@ allumc_linkage_tooltip <- strwrap("This metric shows the percentage of clinical 
                              with a DOI or that are indexed in PubMed. We used automated methods to download
                              the relevant fields from ClinicalTrials.gov and DRKS. We considered a
                              publication “linked” if the PMID or DOI was included in the trial registration.
-                                  More information can be found in the Methods page.")
+                             Select the registry of interest can be selected in the drop-down menu. More
+                                  information can be found in the Methods page.")
 
 lim_allumc_linkage_tooltip <- strwrap("ClinicalTrials.gov includes an often-used
                              PMID field for references. In addition, ClinicalTrials.gov automatically
@@ -97,7 +95,7 @@ lim_allumc_linkage_tooltip <- strwrap("ClinicalTrials.gov includes an often-used
                              was limited to trials with a journal publication which have a DOI or are
                              indexed in PubMed.")
 
-allumc_clinicaltrials_sumres_tooltip <- strwrap("This metric displays the cumulative percentage of due trials that have
+allumc_clinicaltrials_sumres_tooltip <- strwrap("This metric displays the percentage of due trials that have
                              reported summary results in the registry. A timely dissemination of trial
                              results is crucial to make the evidence gained in those trials available.
                              Select to view summary results reporting for trials registered in either the
@@ -139,8 +137,8 @@ lim_allumc_clinicaltrials_prereg_tooltip <- strwrap("This data depends on regist
                              without a start date in the registry were excluded from this analysis.")
 
 allumc_clinicaltrials_timpub_tooltip5a <- strwrap("This metric shows the percentage of clinical trials
-                            that reported results within 5 years of trial completion as (a) summary
-                            results in the registry, and b) a journal publication. Select the reporting
+                            that reported results within 5 years of trial completion as (a) a journal
+                            publication, and b) summary results in the registry. Select the reporting
                             route of interest in the drop-down menu. A fast dissemination of trial
                              results is crucial to make the evidence gained in those trials available.
                              This analysis was limited to trials registered in ClinicalTrials.gov or DRKS. 
@@ -167,8 +165,8 @@ lim_allumc_clinicaltrials_timpub_tooltip5a <- strwrap("<i>Results reporting as s
                              responsible parties were not contacted.")
 
 allumc_clinicaltrials_timpub_tooltip <- strwrap("This metric shows the percentage of clinical trials that
-                            reported results within 2 years of trial completion as (a) summary results
-                            in the registry, and b) a journal publication. Select the reporting route of
+                            reported results within 2 years of trial completion as (a) a journal publication,
+                            and b) summary results in the registry. Select the reporting route of
                             interest in the drop-down menu. A fast dissemination of trial results
                             is crucial to make the evidence gained in those trials available. This analysis was
                              limited to trials registered in ClinicalTrials.gov or DRKS. <i>Results reporting

--- a/all_umcs_page.R
+++ b/all_umcs_page.R
@@ -15,7 +15,7 @@ allumc_openaccess_tooltip <- strwrap("This metric shows the percentage of clinic
                               of gold - hybrid - green. Note that the
                               OA percentage is not fixed but typically rises
                               retrospectively, as some publications become accessible
-                              with a delay. Query date: 10/12/2021. More information
+                              with a delay. Query date: 20/02/2022. More information
                               can be found in the Methods page.")
 
 lim_allumc_openaccess_tooltip <- strwrap("The OA status could only be obtained for publications
@@ -38,7 +38,7 @@ allumc_greenoa_tooltip <- strwrap("This metric shows the percentage of paywalled
                              (if any). Therefore, the number of paywalled publications
                              with the potential for green OA will change over time.
                              The Shareyourpaper permissions API was queried on
-                             10/12/2021. More information can be
+                             20/02/2022. More information can be
                              found in the Methods page.")
 
 lim_allumc_greenoa_tooltip <- strwrap("The OA status and self-archiving permission could

--- a/app.R
+++ b/app.R
@@ -510,9 +510,9 @@ server <- function (input, output, session) {
                         "startreporttype2a",
                         strong("Reporting type"),
                         choices = c(
-                            "Summary results or publication",
-                            "Summary results only",
-                            "Publication only"
+                            #"Summary results or publication",
+                            "Publication only",
+                            "Summary results only"
                         )
                     )
                 ),
@@ -523,9 +523,9 @@ server <- function (input, output, session) {
                         "startreporttype5a",
                         strong("Reporting type"),
                         choices = c(
-                            "Summary results or publication",
-                            "Summary results only",
-                            "Publication only"
+                            #"Summary results or publication",
+                            "Publication only",
+                            "Summary results only"
                         )
                     )
                 )
@@ -1181,9 +1181,9 @@ server <- function (input, output, session) {
                             "reporttype2a",
                             strong("Reporting type"),
                             choices = c(
-                                "Summary results or publication",
-                                "Summary results only",
-                                "Publication only"
+                                #"Summary results or publication",
+                                "Publication only",
+                                "Summary results only"
                             )
                         )
                     ),
@@ -1194,9 +1194,9 @@ server <- function (input, output, session) {
                             "reporttype5a",
                             strong("Reporting type"),
                             choices = c(
-                                "Summary results or publication",
-                                "Summary results only",
-                                "Publication only"
+                                #"Summary results or publication",
+                                "Publication only",
+                                "Summary results only"
                             )
                         )
                     )
@@ -1923,9 +1923,9 @@ server <- function (input, output, session) {
                         "allumcreporttype2a",
                         strong("Reporting type"),
                         choices = c(
-                            "Summary results or publication",
-                            "Summary results only",
-                            "Publication only"
+                            #"Summary results or publication",
+                            "Publication only",
+                            "Summary results only"
                         )
                     )
                 )
@@ -1938,9 +1938,9 @@ server <- function (input, output, session) {
                         "allumcreporttype5a",
                         strong("Reporting type"),
                         choices = c(
-                            "Summary results or publication",
-                            "Summary results only",
-                            "Publication only"
+                            #"Summary results or publication",
+                            "Publication only",
+                            "Summary results only"
                         )
                     )
                     

--- a/app.R
+++ b/app.R
@@ -1690,10 +1690,10 @@ server <- function (input, output, session) {
             value_text = "of trials with a publication provide a link to this publication in the registry entry",
             plot = plotlyOutput('plot_allumc_linkage', height="300px"),
             info_id = "infoALLUMCLinkage",
-            info_title = "Linkage (All UMCs)",
+            info_title = "Publication link in registry (All UMCs)",
             info_text = allumc_linkage_tooltip,
             lim_id = "limALLUMCLinkage",
-            lim_title = "Limitations: Linkage (All UMCs)",
+            lim_title = "Limitations: Publication link in registry (All UMCs)",
             lim_text = lim_allumc_linkage_tooltip
         )
         

--- a/app.R
+++ b/app.R
@@ -627,28 +627,47 @@ server <- function (input, output, session) {
         
         # Filter for 2017 completion date for pink descriptor text
         iv_data_unique <- iv_all %>%
-            filter(completion_year == 2017) %>%
-            filter(has_followup_2y == TRUE)
+            filter(completion_year == 2017)
 
         all_numer_timpub <- iv_data_unique %>%
-            filter(is_publication_2y | is_summary_results_2y) %>%
+            filter(
+                (has_followup_2y_sumres & is_summary_results_2y) | (has_followup_2y_pub & is_publication_2y)
+            ) %>%
+            nrow()
+        
+        all_denom_timpub <- iv_data_unique %>%
+            filter(
+                has_followup_2y_sumres | has_followup_2y_pub
+                ) %>%
             nrow()
 
         if (input$startreporttype2a == "Summary results only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_summary_results_2y) %>%
+                filter(
+                    has_followup_2y_sumres,
+                    is_summary_results_2y) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_2y_sumres
+                ) %>%
                 nrow()
         }
 
         if (input$startreporttype2a == "Publication only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_publication_2y) %>%
-                
+                filter(
+                    has_followup_2y_pub,
+                    is_publication_2y) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_2y_pub
+                ) %>%
                 nrow()
         }
-        
-        all_denom_timpub <- iv_data_unique %>%
-            nrow()
 
         if (all_denom_timpub == 0) {
             timpubval <- "Not applicable"
@@ -678,27 +697,47 @@ server <- function (input, output, session) {
         
         # Filter for 2015 completion date for pink descriptor text
         iv_data_unique <- iv_all %>%
-            filter(completion_year == 2015) %>%
-            filter(has_followup_5y == TRUE)
-
+            filter(completion_year == 2015)
+        
         all_numer_timpub5a <- iv_data_unique %>%
-            filter(is_publication_5y | is_summary_results_5y) %>%
+            filter(
+                (has_followup_5y_sumres & is_summary_results_5y) | (has_followup_5y_pub & is_publication_5y)
+                ) %>%
+            nrow()
+        
+        all_denom_timpub5a <- iv_data_unique %>%
+            filter(
+                has_followup_5y_sumres | has_followup_5y_pub
+            ) %>%
             nrow()
 
         if (input$startreporttype5a == "Summary results only") {
             all_numer_timpub5a <- iv_data_unique %>%
-                filter(is_summary_results_5y) %>%
+                filter(
+                    has_followup_5y_sumres,
+                    is_summary_results_5y) %>%
+                nrow()
+            
+            all_denom_timpub5a <- iv_data_unique %>%
+                filter(
+                    has_followup_5y_sumres
+                ) %>%
                 nrow()
         }
 
         if (input$startreporttype5a == "Publication only") {
             all_numer_timpub5a <- iv_data_unique %>%
-                filter(is_publication_5y) %>%
+                filter(
+                    has_followup_5y_pub,
+                    is_publication_5y) %>%
+                nrow()
+            
+            all_denom_timpub5a <- iv_data_unique %>%
+                filter(
+                    has_followup_5y_pub
+                ) %>%
                 nrow()
         }
-
-        all_denom_timpub5a <- iv_data_unique %>%
-            nrow()
 
         if (all_denom_timpub5a == 0) {
             timpubval5a <- "Not applicable"
@@ -1259,27 +1298,47 @@ server <- function (input, output, session) {
         # Filter for 2017 completion date for the pink descriptor text
         iv_data_unique <- iv_umc %>%
             filter(completion_year == 2017) %>%
-            filter(city == input$selectUMC) %>%
-            filter(has_followup_2y == TRUE)
+            filter(city == input$selectUMC)
 
         all_numer_timpub <- iv_data_unique %>%
-            filter(is_publication_2y | is_summary_results_2y) %>%
+            filter(
+                (has_followup_2y_pub & is_publication_2y) | (has_followup_2y_sumres & is_summary_results_2y)
+                ) %>%
+            nrow()
+        
+        all_denom_timpub <- iv_data_unique %>%
+            filter(
+                has_followup_2y_pub | has_followup_2y_sumres
+            ) %>%
             nrow()
 
         if (input$reporttype2a == "Summary results only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_summary_results_2y) %>%
+                filter(
+                    has_followup_2y_sumres,
+                    is_summary_results_2y) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_2y_sumres
+                ) %>%
                 nrow()
         }
 
         if (input$reporttype2a == "Publication only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_publication_2y) %>%
+                filter(
+                    has_followup_2y_pub,
+                    is_publication_2y) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_2y_pub
+                ) %>%
                 nrow()
         }
-
-        all_denom_timpub <- iv_data_unique %>%
-            nrow()
 
         if (all_denom_timpub == 0) {
             timpubval <- "Not applicable"
@@ -1309,28 +1368,46 @@ server <- function (input, output, session) {
         # Filter for 2015 completion date for the pink descriptor text
         iv_data_unique <- iv_umc %>%
             filter(completion_year == 2015) %>%
-            filter(city == input$selectUMC) %>%
-            filter(has_followup_5y == TRUE)
+            filter(city == input$selectUMC)
             
-        
         all_numer_timpub <- iv_data_unique %>%
-            filter(is_publication_5y | is_summary_results_5y) %>%
+            filter(
+                (has_followup_5y_pub & is_publication_5y) | (has_followup_5y_sumres & is_summary_results_5y)
+                ) %>%
+            nrow()
+        
+        all_denom_timpub <- iv_data_unique %>%
+            filter(
+                has_followup_5y_pub | has_followup_5y_sumres
+            ) %>%
             nrow()
 
         if (input$reporttype5a == "Summary results only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_summary_results_5y) %>%
+                filter(
+                    has_followup_5y_sumres,
+                    is_summary_results_5y) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_5y_sumres
+                ) %>%
                 nrow()
         }
 
         if (input$reporttype5a == "Publication only") {
             all_numer_timpub <- iv_data_unique %>%
-                filter(is_publication_5y) %>%
+                filter(
+                    has_followup_5y_pub,
+                    is_publication_5y) %>%
                 nrow()
+            
+            all_denom_timpub <- iv_data_unique %>%
+                filter(
+                    has_followup_5y_pub
+                ) %>% nrow()
         }
-
-        all_denom_timpub <- iv_data_unique %>%
-            nrow()
 
         if (all_denom_timpub == 0) {
             timpubval <- "Not applicable"
@@ -1880,8 +1957,13 @@ server <- function (input, output, session) {
 
         all_numer_timpub <- iv_all %>%
             filter(
-                is_publication_2y | is_summary_results_2y,
-                has_followup_2y == TRUE
+                (has_followup_2y_pub & is_publication_2y) | (has_followup_2y_sumres & is_summary_results_2y)
+            ) %>%
+            nrow()
+        
+        all_denom_timpub <- iv_all %>%
+            filter(
+                has_followup_2y_pub | has_followup_2y_sumres
             ) %>%
             nrow()
 
@@ -1889,8 +1971,14 @@ server <- function (input, output, session) {
 
             all_numer_timpub <- iv_all %>%
                 filter(
-                    is_summary_results_2y,
-                    has_followup_2y == TRUE
+                    has_followup_2y_sumres,
+                    is_summary_results_2y
+                ) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_all %>%
+                filter(
+                    has_followup_2y_sumres
                 ) %>%
                 nrow()
         }
@@ -1899,15 +1987,17 @@ server <- function (input, output, session) {
 
             all_numer_timpub <- iv_all %>%
                 filter(
-                    is_publication_2y,
-                    has_followup_2y == TRUE
+                    has_followup_2y_pub,
+                    is_publication_2y
+                ) %>%
+                nrow()
+            
+            all_denom_timpub <- iv_all %>%
+                filter(
+                    has_followup_2y_pub
                 ) %>%
                 nrow()
         }
-
-        all_denom_timpub <- iv_all %>%
-            filter(has_followup_2y == TRUE) %>%
-            nrow()
 
         metric_box(
             title = "Results reporting within 2 years of trial completion (timely)",
@@ -1931,17 +2021,28 @@ server <- function (input, output, session) {
 
         all_numer_timpub5a <- iv_all %>%
             filter(
-                is_publication_5y | is_summary_results_5y,
-                has_followup_5y == TRUE
+                (has_followup_5y_pub & is_publication_5y) | (has_followup_5y_sumres & is_summary_results_5y)
             ) %>%
+            nrow()
+        
+        all_denom_timpub5a <- iv_all %>%
+            filter(
+                has_followup_5y_pub | has_followup_5y_sumres
+                ) %>%
             nrow()
 
         if (input$allumcreporttype5a == "Summary results only") {
 
             all_numer_timpub5a <- iv_all %>%
                 filter(
-                    is_summary_results_5y,
-                    has_followup_5y == TRUE
+                    has_followup_5y_sumres,
+                    is_summary_results_5y
+                ) %>%
+                nrow()
+            
+            all_denom_timpub5a <- iv_all %>%
+                filter(
+                    has_followup_5y_sumres
                 ) %>%
                 nrow()
         }
@@ -1950,15 +2051,17 @@ server <- function (input, output, session) {
 
             all_numer_timpub5a <- iv_all %>%
                 filter(
-                    is_publication_5y,
-                    has_followup_5y == TRUE
+                    has_followup_5y_pub,
+                    is_publication_5y
+                ) %>%
+                nrow()
+            
+            all_denom_timpub5a <- iv_all %>%
+                filter(
+                    has_followup_5y_pub
                 ) %>%
                 nrow()
         }
-
-        all_denom_timpub5a <- iv_all %>%
-            filter(has_followup_5y == TRUE) %>%
-            nrow()
 
         metric_box(
             title = "Results reporting within 5 years of trial completion",

--- a/faq_page.R
+++ b/faq_page.R
@@ -178,7 +178,7 @@ faq_page <- tabPanel(
                                       on <b>6 October 2021</b>.<br>
                                       <br>For summary results reporting in the
                                       EUCTR, we extracted data from the EU Trials
-                                      Tracker on <b>6 December 2021</b>.")),
+                                      Tracker on <b>18 February 2022</b>.")),
                                value = "faqPanels_UpToDate",
                                style = "default")),
     bsCollapse(id = "faqPanels_MoreMethods",
@@ -211,7 +211,7 @@ faq_page <- tabPanel(
                                publications. All data processing steps are
                                available and documented in <a href=https://github.com/maia-sh/intovalue-data>GitHub</a>.
                                More details on the methods to detect trial and
-                               publication linkage can be found in this
+                               publication links can be found in this
                                <a href=https://www.medrxiv.org/content/10.1101/2021.08.23.21262478v1>preprint</a>
                                and in <a href=https://github.com/maia-sh/reg-pub-link>GitHub</a>.
                                The dashboard was developed with Shiny and the

--- a/methods_page.R
+++ b/methods_page.R
@@ -71,7 +71,7 @@ methods_page <- tabPanel(
                                <a href=https://github.com/maia-sh/intovalue-data>
                                associated code repository in GitHub</a>. Three German UMCs
                                (Augsburg, Bielefeld, and Oldenburg) were founded after
-                               the start of data collection. Note that in this cohort,
+                               the start of data collection. In this cohort,
                                Kiel and Lübeck are represented as a single UMC
                                (Schleswig-Holstein).<br>
                                 
@@ -82,8 +82,8 @@ methods_page <- tabPanel(
                                       and considered as \"complete\" per the study
                                       status in the registry. We downloaded updated
                                       registry data for the trials in this cohort on
-                                      6 October 2021. Note that in this cohort,
-                                      Kiel and Lübeck are represented as separate UMCs.<br>
+                                      6 October 2021. In this cohort, Kiel and Lübeck are
+                                      represented as a single UMC (Schleswig-Holstein)<br>
                                       
                             <br>3. <b>Summary results reporting in the EUCTR</b>: this
                             assessment was based on the
@@ -227,7 +227,7 @@ methods_page <- tabPanel(
                              trials, and total number of trials that reported results) from historical
                              versions of the EU Trials Tracker&#39s (EBM DataLab) 
                              <a href=https://github.com/ebmdatalab/euctr-tracker-data>code repository</a>
-                             (latest data extracted on 6 December 2021). While the EU Trials Tracker is
+                             (latest data extracted on 18 February 2022). While the EU Trials Tracker is
                              usually updated monthly, in some cases there was more than one update within
                              the same month. In these cases, only the latest data point within that month
                              was displayed. Note that some trials registered in EudraCT and captured in
@@ -260,7 +260,15 @@ methods_page <- tabPanel(
                              
                              HTML('This analysis was limited to trials in the IntoValue dataset
                                 (registered in ClinicalTrials.gov or DRKS). <i>Results reporting as
-                                summary results in the registry</i>: see above. <i>Results reporting
+                                summary results in the registry</i>: Summary results posting was extracted
+                                from ClinicalTrials.gov and DRKS via automated methods. ClinicalTrials.gov
+                                includes a structured summary results field. In contrast, DRKS includes
+                                summary results with other references. In the absence of a structured summary
+                                results field in DRKS, we detected summary results in this registry based on
+                                the presence of keywords (e.g., Ergebnisbericht or Abschlussbericht) in the
+                                reference title. The summary results date in DRKS was extracted manually from
+                                the registry’s change history (which indicates when the summary result was
+                                  uploaded). <i>Results reporting
                                 as a journal publication</i>: this data was previously obtained as
                                 part of the <a href=https://doi.org/10.1016/j.jclinepi.2019.06.002>
                              IntoValue 1 study</a> and the follow-up 
@@ -271,11 +279,14 @@ methods_page <- tabPanel(
                              does not reflect all result publications of a given trial. Publication dates
                              were manually entered during publication searches.<br>
                              <br>When calculating the 2-year and 5-year reporting
-                             rates, we only considered trials for which we had 2 and 5 years follow-up
-                             time since trial completion, respectively. The plot only displays data for
-                             completion years with more than 5 trials. Note for the One UMC page: in
-                             case there were no trials for a given UMC and completion year (denominator = 0),
-                             the data point for this completion year is omitted in the plot.'),
+                             rates (summary results), we only considered trials for which we had 2 and 5 years
+                             follow-up time from trial completion to the registry query date, respectively. When
+                             calculating the 2-year and 5-year reporting rates (journal publication), we only
+                             considered trials for which we had 2 and 5 years follow-up time from trial completion
+                             to the manual search date, respectively. The plot only displays data for completion
+                             years with more than 5 trials. Note for the One UMC page: in case there were no trials
+                             for a given UMC and completion year (denominator = 0), the data point for this
+                             completion year is omitted in the plot.'),
                              
                              HTML("<i>Results reporting as summary results in the registry</i>:
                                 ClinicalTrials.gov includes a structured summary results field. In contrast,
@@ -283,9 +294,15 @@ methods_page <- tabPanel(
                              inferred based on keywords, such as \"Ergebnisbericht\" or \"Abschlussbericht\",
                              in the reference title. The data presented relies on the information in registry
                              entries being accurate and complete. <i>Results reporting as a journal
-                             publication</i>: some of the publications may have been missed in the manual
-                             search procedure as the search was restricted to a limited number of
-                             scientific databases and the responsible parties were not contacted."))),
+                             publication</i>: The manual searches for trial results publications in the
+                                  IntoValue 1 cohort (trials completed between 2009 – 2013) were performed
+                                  between July 2017 and December 2017. The manual searches for trial results
+                                  publications in the IntoValue 2 cohort (trials completed between 2014 – 2017)
+                                  were performed between July 2020 and September 2020. Trial results
+                                  publications published after these manual searches were conducted would
+                                  have been missed. Furthermore, some publications may have been missed in the
+                                  manual search procedure as the search was restricted to a limited number of
+                                  scientific databases and the responsible parties were not contacted."))),
     
     hr(),
     h3("Open Access"),
@@ -336,7 +353,7 @@ methods_page <- tabPanel(
                         are often made available with a delay. Therefore, the OA percentage for a given
                         year typically rises retrospectively. Thus, the point in time
                         at which the OA status is retrieved is important for the OA percentage. The latest
-                        OA data was retrieved with UnpaywallR on: 10/12/2021.'),
+                        OA data was retrieved with UnpaywallR on: 20/02/2022.'),
                              
                              "The OA status could only be obtained for publications with a DOI and
                              which resolved in Unpaywall. We did not perform a manual check of the OA data."),
@@ -382,7 +399,7 @@ methods_page <- tabPanel(
                              the publication date and the length of the embargo (if any). Therefore,
                              the number of paywalled publications with the potential for green OA will
                              change over time. The Unpaywall database and the Shareyourpaper permissions
-                             API were queried on 10/12/2021. The plots for this metric on the Start page
+                             API were queried on 20/02/2022. The plots for this metric on the Start page
                              only display data for years with more than 20 publications.'),
                              
                              "Not all queried publications resolved in Unpaywall and ShareYourPaper.
@@ -437,7 +454,7 @@ openaccess_tooltip <- strwrap("This metric shows the percentage of clinical tria
                               in this dashboard are also included. Note that the
                               OA percentage is not fixed but typically rises
                               retrospectively, as some publications become accessible
-                              with a delay. Query date: 10/12/2021. Start page: only
+                              with a delay. Query date: 20/02/2022. Start page: only
                               publication years with more than 20 publications are shown.
                               More information can be found in the Methods page.") %>%
     paste(collapse = " ")
@@ -463,7 +480,7 @@ greenopenaccess_tooltip <- strwrap('This metric shows the percentage of paywalle
                              (if any). Therefore, the number of paywalled publications
                              with the potential for green OA will change over time.
                              The Shareyourpaper permissions API was queried on
-                             10/12/2021. Start page: only publication years with more than
+                             20/02/2022. Start page: only publication years with more than
                              20 publications are shown. More information can be
                              found in the Methods page.') %>%
     paste(collapse = " ")

--- a/methods_page.R
+++ b/methods_page.R
@@ -61,7 +61,7 @@ methods_page <- tabPanel(
                                using the registry's change history; (3)
                                we included additional information on the reporting
                                of trial registration numbers in trial results
-                               publications, publication linkage in the registry,
+                               publications, publication links in the registry,
                                and Open Access; (4) while the original IntoValue
                                dataset considered both journal publications and
                                dissertations as results publications, we focused
@@ -154,7 +154,7 @@ methods_page <- tabPanel(
                                 in PubMed (detection of TRN in abstract) or for which we could obtain the
                                 full text (detection of TRN in full text).")),
                
-               methods_panel("Linkage of journal publications in the registry",
+               methods_panel("Publication links in the registry",
                              
                              HTML("How many clinical trials with a results publication have a link to
                                 this publication in the registry. Linking to the publication in

--- a/methods_page.R
+++ b/methods_page.R
@@ -250,8 +250,8 @@ methods_page <- tabPanel(
                methods_panel("Results reporting (2-year and 5-year reporting)",
                              
                              HTML("How many clinical trials reported results within 2 and 5
-                             years of trial completion as (a) summary results in the registry, and
-                             b) a journal publication. A fast dissemination of trial
+                             years of trial completion as (a) a journal publication, and b) summary results
+                             in the registry. A fast dissemination of trial
                              results is crucial to make the evidence gained in those trials available.
                              The <a href=https://www.who.int/news/item/18-05-2017-joint-statement-on-registration>
                         World Health Organization</a> recommends publishing registry summary results within
@@ -278,12 +278,12 @@ methods_page <- tabPanel(
                              the earliest was included. The data presented in this dashboard therefore
                              does not reflect all result publications of a given trial. Publication dates
                              were manually entered during publication searches.<br>
-                             <br>When calculating the 2-year and 5-year reporting
-                             rates (summary results), we only considered trials for which we had 2 and 5 years
+                             <br><b>When calculating the 2-year and 5-year reporting
+                             rates (summary results), we only included trials for which we had 2 and 5 years
                              follow-up time from trial completion to the registry query date, respectively. When
                              calculating the 2-year and 5-year reporting rates (journal publication), we only
-                             considered trials for which we had 2 and 5 years follow-up time from trial completion
-                             to the manual search date, respectively. The plot only displays data for completion
+                             included trials for which we had 2 and 5 years follow-up time from trial completion
+                             to the manual search date, respectively</b>. The plot only displays data for completion
                              years with more than 5 trials. Note for the One UMC page: in case there were no trials
                              for a given UMC and completion year (denominator = 0), the data point for this
                              completion year is omitted in the plot.'),
@@ -345,7 +345,7 @@ methods_page <- tabPanel(
                              for each publication only assigned the category with the highest priority.
                              We used a hierarchy of gold - hybrid - green. A more detailed breakdown
                              of the absolute number of publications across all categories can be
-                             visualised by clicking on the toggle next to the plot. The plots for
+                             visualised by clicking on the toggle above the plot. The plots for
                              this metric on the Start page only display data for years with more
                              than 20 publications.
                         <br>
@@ -353,7 +353,7 @@ methods_page <- tabPanel(
                         are often made available with a delay. Therefore, the OA percentage for a given
                         year typically rises retrospectively. Thus, the point in time
                         at which the OA status is retrieved is important for the OA percentage. The latest
-                        OA data was retrieved with UnpaywallR on: 20/02/2022.'),
+                        OA data was retrieved with UnpaywallR on 20 February 2022.'),
                              
                              "The OA status could only be obtained for publications with a DOI and
                              which resolved in Unpaywall. We did not perform a manual check of the OA data."),
@@ -372,18 +372,20 @@ methods_page <- tabPanel(
                              it is to be deposited. Moreover, in many cases only the accepted version
                              of the publication can be archived after an embargo period of 6 or 12 months.
                              It can be difficult to retrieve the correct version of the publication after this
-                             delay."),
+                             delay. Click on the toggle to view absolute numbers (light green shows the number
+                             of publications currently behind a paywall that have a permission for self-archiving
+                             in an institutional repository)."),
                              
                              HTML('This analysis was limited to trials in the IntoValue dataset (registered
                                 in ClinicalTrials.gov or DRKS) with a journal publication and a DOI. The
                                 publication date from Unpaywall was used to display the data over
                              time. Therefore, this analysis was also limited to publications with a
-                             publication date in Unpaywall. In a first step, we identified publications
+                             publication date in Unpaywall. In the first step, we identified publications
                              which are
                              only accessible in a repository (Green OA only). To do so, we queried Unpaywall
                              via its API using the <a href="https://github.com/NicoRiedel/unpaywallR">
                              UnpaywallR R package</a>) with the following hierarchy: gold - hybrid - bronze - green - 
-                             closed. In a second step, we identified how many paywalled publications
+                             closed. In the second step, we identified how many paywalled publications
                              could technically be made openly accessible based on self-archiving permissions.
                              We obtained article-level self-archiving permissions by querying
                              Shareyourpaper.org (OA.Works) via its
@@ -399,7 +401,7 @@ methods_page <- tabPanel(
                              the publication date and the length of the embargo (if any). Therefore,
                              the number of paywalled publications with the potential for green OA will
                              change over time. The Unpaywall database and the Shareyourpaper permissions
-                             API were queried on 20/02/2022. The plots for this metric on the Start page
+                             API were queried on 20 February 2022. The plots for this metric on the Start page
                              only display data for years with more than 20 publications.'),
                              
                              "Not all queried publications resolved in Unpaywall and ShareYourPaper.
@@ -449,7 +451,7 @@ openaccess_tooltip <- strwrap("This metric shows the percentage of clinical tria
                               with the highest priority. Here, we used a hierarchy
                               of gold - hybrid - green. The absolute number of
                               publications and their OA status can be visualised
-                              by clicking on the toggle next to the plot. Here,
+                              by clicking on the toggle above the plot. Here,
                               further categories not considered as Open Access
                               in this dashboard are also included. Note that the
                               OA percentage is not fixed but typically rises
@@ -467,11 +469,11 @@ greenopenaccess_tooltip <- strwrap('This metric shows the percentage of paywalle
                             that have been made openly accessible in a repository (green OA).
                             Click on the toggle to view absolute
                             numbers (light green shows the number of publications currently behind a
-                            paywall that could be made openly accessible in a repository based on
-                            self-archiving permissions). This analysis was
+                            paywall that have a permission for self-archiving in an institutional
+                            repository). This analysis was
                               limited to trials registered in ClinicalTrials.gov
                               or DRKS with a journal publication and a DOI that
-                              resolved in Unpaywall. In a first step, we queried the Unpaywall API to identify
+                              resolved in Unpaywall. In the first step, we queried the Unpaywall API to identify
                             publications that are only accessible in a repository (Green OA only).
                             Next, we queried Shareyourpaper.org (OA.Works) via its API to obtain
                             self-archiving permissions of paywalled publications. The date at
@@ -540,6 +542,7 @@ linkage_tooltip <- strwrap("This metric shows the percentage of clinical trials 
                              with a DOI or that are indexed in PubMed. We used automated methods to download
                              the relevant fields from ClinicalTrials.gov and DRKS. We considered a
                              publication “linked” if the PMID or DOI was included in the trial registration.
+                             Select the registry of interest can be selected in the drop-down menu.
                              More information can be found in the Methods page.")
 
 lim_linkage_tooltip <- strwrap("ClinicalTrials.gov includes an often-used
@@ -594,8 +597,8 @@ lim_prereg_tooltip <- strwrap("This data depends on registry entries being accur
                              without a start date in the registry were excluded from this analysis.")
 
 timpub_tooltip2 <- strwrap("This metric shows the percentage of clinical trials that reported results within
-                             2 years of trial completion as (a) summary results in the registry, and b) 
-                             a journal publication. Select the reporting route of interest in the drop-down menu.
+                             2 years of trial completion as (a) a journal publication, and b) summary results
+                             in the registry. Select the reporting route of interest in the drop-down menu.
                              A fast dissemination of trial results is crucial to make the evidence gained in
                              those trials available.
                              This analysis was limited to trials registered in ClinicalTrials.gov or DRKS. 
@@ -625,8 +628,8 @@ lim_timpub_tooltip2 <- strwrap("<i>Results reporting as summary results in the r
                              responsible parties were not contacted.")
 
 timpub_tooltip5 <- strwrap("This metric shows the percentage of clinical trials that reported results within
-                             5 years of trial completion as (a) summary results in the registry, and b) 
-                             a journal publication. Select the reporting route of interest in the drop-down menu.
+                             5 years of trial completion as (a) a journal publication, and b) summary results
+                             in the registry. Select the reporting route of interest in the drop-down menu.
                              A fast dissemination of trial
                              results is crucial to make the evidence gained in those trials available.
                              This analysis was limited to trials registered in ClinicalTrials.gov or DRKS.

--- a/methods_page.R
+++ b/methods_page.R
@@ -280,7 +280,7 @@ methods_page <- tabPanel(
                              were manually entered during publication searches.<br>
                              <br><b>When calculating the 2-year and 5-year reporting
                              rates (summary results), we only included trials for which we had 2 and 5 years
-                             follow-up time from trial completion to the registry query date, respectively. When
+                             follow-up time from trial completion to the registry download date, respectively. When
                              calculating the 2-year and 5-year reporting rates (journal publication), we only
                              included trials for which we had 2 and 5 years follow-up time from trial completion
                              to the manual search date, respectively</b>. The plot only displays data for completion

--- a/start_page_plots.R
+++ b/start_page_plots.R
@@ -361,21 +361,31 @@ plot_clinicaltrials_sumres <- function (eutt_dataset, iv_dataset, toggled_regist
 # Timely publication within 2 years
 plot_clinicaltrials_timpub_2a <- function (dataset, rt, color_palette) {
 
-    dataset <- dataset %>%
-        filter(has_followup_2y == TRUE)
-
     if (rt != "Summary results or publication") {
 
         if (rt == "Summary results only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_2y_sumres
+                )
             dataset$published_2a <- dataset$is_summary_results_2y
         }
         
         if (rt == "Publication only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_2y_pub
+                )
             dataset$published_2a <- dataset$is_publication_2y
         }
         
     } else {
-        dataset$published_2a <- dataset$is_summary_results_2y | dataset$is_publication_2y
+        dataset <- dataset %>%
+            filter(
+                has_followup_2y_sumres | has_followup_2y_pub
+            )
+        dataset$published_2a <- (dataset$has_followup_2y_sumres & dataset$is_summary_results_2y) | 
+            (dataset$has_followup_2y_pub & dataset$is_publication_2y)
     }
 
     umc <- "All"
@@ -453,22 +463,32 @@ plot_clinicaltrials_timpub_2a <- function (dataset, rt, color_palette) {
 
 # Timely publication within 5 years
 plot_clinicaltrials_timpub_5a <- function (dataset, rt, color_palette) {
-
-    dataset <- dataset %>%
-        filter(has_followup_5y == TRUE)
     
     if (rt != "Summary results or publication") {
 
         if (rt == "Summary results only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_5y_sumres
+                )
             dataset$published_5a <- dataset$is_summary_results_5y
         }
         
         if (rt == "Publication only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_5y_pub
+                )
             dataset$published_5a <- dataset$is_publication_5y
         }
         
     } else {
-        dataset$published_5a <- dataset$is_summary_results_5y | dataset$is_publication_5y
+        dataset <- dataset %>%
+            filter(
+                has_followup_5y_sumres | has_followup_5y_pub
+            )
+        dataset$published_5a <- (dataset$has_followup_5y_sumres & dataset$is_summary_results_5y) | 
+            (dataset$has_followup_5y_pub & dataset$is_publication_5y)
     }
 
     umc <- "All"

--- a/umc_plots.R
+++ b/umc_plots.R
@@ -535,27 +535,50 @@ umc_plot_clinicaltrials_sumres <- function (eutt_dataset, iv_dataset, iv_all_dat
 # Timely publication within 2 years
 umc_plot_clinicaltrials_timpub_2a <- function (dataset, dataset_all, umc, rt, color_palette) {
 
-    dataset <- dataset %>%
-        filter(has_followup_2y == TRUE)
-    
-    dataset_all <- dataset_all %>%
-        filter(has_followup_2y == TRUE)
-
     if (rt != "Summary results or publication") {
 
         if (rt == "Summary results only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_2y_sumres
+                )
             dataset$published_2a <- dataset$is_summary_results_2y
+            
+            dataset_all <- dataset_all %>%
+                filter(
+                    has_followup_2y_sumres
+                )
             dataset_all$published_2a <- dataset_all$is_summary_results_2y
         }
         
         if (rt == "Publication only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_2y_pub
+                )
             dataset$published_2a <- dataset$is_publication_2y
+            
+            dataset_all <- dataset_all %>%
+                filter(
+                    has_followup_2y_pub
+                )
             dataset_all$published_2a <- dataset_all$is_publication_2y
         }
         
     } else {
-        dataset$published_2a <- dataset$is_summary_results_2y | dataset$is_publication_2y
-        dataset_all$published_2a <- dataset_all$is_summary_results_2y | dataset_all$is_publication_2y
+        dataset <- dataset %>%
+            filter(
+                has_followup_2y_pub | has_followup_2y_sumres
+            )
+        dataset$published_2a <- (dataset$has_followup_2y_sumres & dataset$is_summary_results_2y) | 
+            (dataset$has_followup_2y_pub & dataset$is_publication_2y)
+        
+        dataset_all <- dataset_all %>%
+            filter(
+                has_followup_2y_pub | has_followup_2y_sumres
+            )
+        dataset_all$published_2a <- (dataset_all$has_followup_2y_sumres & dataset_all$is_summary_results_2y) | 
+            (dataset_all$has_followup_2y_pub & dataset_all$is_publication_2y)
     }
 
     years <- seq(from=min(dataset$completion_year), to=max(dataset$completion_year))
@@ -661,27 +684,50 @@ umc_plot_clinicaltrials_timpub_2a <- function (dataset, dataset_all, umc, rt, co
 # Timely publication within 5 years
 umc_plot_clinicaltrials_timpub_5a <- function (dataset, dataset_all, umc, rt, color_palette) {
 
-    dataset <- dataset %>%
-        filter(has_followup_5y == TRUE)
-    
-    dataset_all <- dataset_all %>%
-        filter(has_followup_5y == TRUE)
-
     if (rt != "Summary results or publication") {
 
         if (rt == "Summary results only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_5y_sumres
+                )
             dataset$published_5a <- dataset$is_summary_results_5y
+            
+            dataset_all <- dataset_all %>%
+                filter(
+                    has_followup_5y_sumres
+                )
             dataset_all$published_5a <- dataset_all$is_summary_results_5y
         }
         
         if (rt == "Publication only") {
+            dataset <- dataset %>%
+                filter(
+                    has_followup_5y_pub
+                )
             dataset$published_5a <- dataset$is_publication_5y
+            
+            dataset_all <- dataset_all %>%
+                filter(
+                    has_followup_5y_pub
+                )
             dataset_all$published_5a <- dataset_all$is_publication_5y
         }
         
     } else {
-        dataset$published_5a <- dataset$is_summary_results_5y | dataset$is_publication_5y
-        dataset_all$published_5a <- dataset_all$is_summary_results_5y | dataset_all$is_publication_5y
+        dataset <- dataset %>%
+            filter(
+                has_followup_5y_pub | has_followup_5y_sumres
+            )
+        dataset$published_5a <- (dataset$has_followup_5y_sumres & dataset$is_summary_results_5y) | 
+            (dataset$has_followup_5y_pub & dataset$is_publication_5y)
+        
+        dataset_all <- dataset_all %>%
+            filter(
+                has_followup_5y_pub | has_followup_5y_sumres
+            )
+        dataset_all$published_5a <- (dataset_all$has_followup_5y_sumres & dataset_all$is_summary_results_5y) | 
+            (dataset_all$has_followup_5y_pub & dataset_all$is_publication_5y)
     }
 
     years <- seq(from=min(dataset$completion_year), to=max(dataset$completion_year))


### PR DESCRIPTION
- Align with update to intovalue dataset (https://github.com/maia-sh/intovalue-data/pull/25) with separate follow-up variables for reporting as summary results (based on the registry download date) and for reporting as a journal publication (based on the manual publication search)
  - [ ] TODO: @bgcarlisle the new follow-up variable for summary results reporting led to us also having trials completed in 2016 for the summary results route. This leads to a mismatch between the pink descriptor text and the last completion year on the x axis in the 5-yr reporting plot (both in the Start and One UMC pages). I held off on changing that but we can consider adapting such that the pink descriptor text is based on latest available completion date. What do you think? 
- Only show "publication only" and "summary results only" for the 2- and 5-year reporting plots (decision made on 22/02/2022 based on different follow-up times and hence denominators for reporting as summary results and as journal publication) 
- Changed "linkage" to "publication links" (resolves https://github.com/quest-bih/clinical-dashboard/issues/50)
- Updates to the FAQ, methods and tooltips, including updated query dates